### PR TITLE
Adds functions to query running jobs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,7 @@
 ## Changes between Quartzite 1.1.0 and 1.2.0
 
-No changes yet.
-
+* `clojurewerkz.quartzite.scheduler/get-currently-executing-jobs` Returns a set of currently executing jobs
+* `clojurewerkz.quartzite.scheduler/currently-executing-job?` Returns true there is a running job for a given key
 
 
 ## Changes between Quartzite 1.0.0 and 1.1.0

--- a/src/clojure/clojurewerkz/quartzite/scheduler.clj
+++ b/src/clojure/clojurewerkz/quartzite/scheduler.clj
@@ -1,5 +1,5 @@
 (ns clojurewerkz.quartzite.scheduler
-  (:import [org.quartz Scheduler JobDetail JobKey Trigger TriggerKey SchedulerListener ListenerManager]
+  (:import [org.quartz Scheduler JobDetail JobKey Trigger TriggerKey SchedulerListener ListenerManager JobExecutionContext]
            org.quartz.impl.matchers.GroupMatcher
            java.util.List)
   (:require [clojurewerkz.quartzite.jobs :as j]
@@ -226,6 +226,17 @@
   "Returns a set of JobDetail instances for the given collection of keys."
   [keys]
   (map get-job keys))
+
+(defn get-currently-executing-jobs
+  "Returns a set of JobExecutionContext that represent the currently executing jobs for a given key"
+  [key]
+  (filter #(= (.. ^JobExecutionContext % (getJobDetail) (getKey)) (j/key key))
+          (.getCurrentlyExecutingJobs ^Scheduler @*scheduler*)))
+
+(defn currently-executing-job?
+  "Returns true if there is currently executing job for the given key"
+  [key]
+  (if (seq (get-currently-executing-jobs key)) true false))
 
 (defn get-trigger-keys
   "Returns a set of keys that match the given group matcher. Commonly used with the functions in the clojurewerkz.quartzite.matchers.*


### PR DESCRIPTION
Solves issue #5 - Two new functions are available in scheduler namespace:
- get-currently-executing-jobs returns a list of executing jobs
  for a given key
- currently-executing-job? returns true if there is a running
  job for a given key
