### PR TITLE
Stringify all keys when converting map to JobDataMap skipping nested maps.

### DIFF
--- a/src/clojure/clojurewerkz/quartzite/conversion.clj
+++ b/src/clojure/clojurewerkz/quartzite/conversion.clj
@@ -9,13 +9,24 @@
 
 (ns clojurewerkz.quartzite.conversion
   (:refer-clojure :exclude [key])
-  (:require [clojure.walk :as wlk])
   (:import [org.quartz JobDataMap JobExecutionContext]
            org.quartz.utils.Key
            [org.quartz TriggerKey JobKey]
            clojure.lang.IPersistentMap
            [org.quartz JobDetail Trigger]))
 
+;;
+;; Implementation
+;;
+
+(defn- convert-keys-to-strings
+  "Converts keys of a map to strings. Doesn't modify nested maps"
+  [map]
+  (->> (for [[k v] map]
+         (if (keyword? k)
+           [(name k) v]
+           [(str k) v]))
+       (into {})))
 
 ;;
 ;; API
@@ -30,12 +41,12 @@
 (extend-protocol JobDataMapConversion
   IPersistentMap
   (to-job-data [^clojure.lang.IPersistentMap input]
-    (JobDataMap. (wlk/stringify-keys input)))
+    (JobDataMap. (convert-keys-to-strings input)))
 
 
   JobDataMap
   (from-job-data [^JobDataMap input]
-    (wlk/stringify-keys (into {} input)))
+    (into {} input))
 
   JobExecutionContext
   (from-job-data [^JobExecutionContext input]

--- a/test/clojurewerkz/quartzite/test/conversion_test.clj
+++ b/test/clojurewerkz/quartzite/test/conversion_test.clj
@@ -1,0 +1,39 @@
+(ns clojurewerkz.quartzite.test.stateful-test
+  (:require [clojure.test :refer :all]
+            [clojurewerkz.quartzite.conversion :refer :all]))
+
+(defrecord Abc [a b c])
+
+(deftest test-job-data-conversion
+  (are [input expected] (= (from-job-data (to-job-data input))
+                           (or expected input))
+
+       ; Simple case..
+       {"string" "hello"
+        "number" 123
+        "boolean" true
+        "character" \newline
+        "keyword" :keyword
+        "symbol" 'symbol}
+       nil ; nil means that expected is same as input
+
+        ; Check that first-level keys are stringified
+       {123 123
+        true true
+        \newline \newline
+        :keyword :keyword
+        'symbol 'symbol}
+       {"123" 123
+        "true" true
+        "\n" \newline
+        "keyword" :keyword
+        "symbol" 'symbol}
+
+        ; Check that keys of nested maps not stringified.
+        {"nested" {:a :a}}
+        nil
+
+        ; Check that nested record not converted to map.
+        {"record" (->Abc :a :b :c)}
+        nil))
+


### PR DESCRIPTION
Contains 2 changes:
  1. Stringify all keys from a map, not only keywords. Before that change non-keyword keys like numbers, symbols weren't converted to strings. Seems like all keys should be strings based on description from this commit: https://github.com/michaelklishin/quartzite/commit/ff5e37e98da06f24dca656609185b2768ce38db7
  2. Don't convert nested maps. Fixes #12.

Added unit test that covers both changes.