### PR TITLE
Fix tests broken by commit 8668bf9230122c

### DIFF
--- a/test/clojurewerkz/quartzite/test/jobs_test.clj
+++ b/test/clojurewerkz/quartzite/test/jobs_test.clj
@@ -81,7 +81,7 @@
     (is (= 100             (.get output "long")))))
 
 (deftest test-conversion-of-job-data-maps-to-clojure-maps
-  (let [input  (JobDataMap. {:keyword :clojure "string" "Hello, Quartz" :long 100})
+  (let [input  (JobDataMap. {"keyword" :clojure "string" "Hello, Quartz" "long" 100})
         output (from-job-data input)]
     (is (map? output))
     (is (= :clojure        (get output "keyword")))


### PR DESCRIPTION
Apparently I broke tests in #16. This commit fixes them. `JobDataMap` is a map that have string keys so we should pass such map to it. The fix does it. Hopefully it should fix travis build.