### PR TITLE
Fixes (2) failing tests

### DIFF
--- a/src/clojure/clojurewerkz/quartzite/conversion.clj
+++ b/src/clojure/clojurewerkz/quartzite/conversion.clj
@@ -46,7 +46,7 @@
 
   JobDataMap
   (from-job-data [^JobDataMap input]
-    (into {} input))
+    (into {} (convert-keys-to-strings input)))
 
   JobExecutionContext
   (from-job-data [^JobExecutionContext input]


### PR DESCRIPTION
Fixes these failures:

```
$ lein test :only clojurewerkz.quartzite.test.jobs-test

lein test clojurewerkz.quartzite.test.jobs-test

lein test :only clojurewerkz.quartzite.test.jobs-test/test-conversion-of-job-data-maps-to-clojure-maps

FAIL in (test-conversion-of-job-data-maps-to-clojure-maps) (jobs_test.clj:87)
expected: (= :clojure (get output "keyword"))
  actual: (not (= :clojure nil))

lein test :only clojurewerkz.quartzite.test.jobs-test/test-conversion-of-job-data-maps-to-clojure-maps

FAIL in (test-conversion-of-job-data-maps-to-clojure-maps) (jobs_test.clj:89)
expected: (= 100 (get output "long"))
  actual: (not (= 100 nil))

Ran 9 tests containing 20 assertions.
2 failures, 0 errors.
Tests failed.

```