### PR TITLE
fix get-job to create key with group & id in correct places

### DIFF
--- a/src/clojure/clojurewerkz/quartzite/scheduler.clj
+++ b/src/clojure/clojurewerkz/quartzite/scheduler.clj
@@ -187,7 +187,7 @@
   ([^Scheduler scheduler key]
      (.getJobDetail ^Scheduler scheduler (to-job-key key)))
   ([^Scheduler scheduler ^String group ^String key]
-     (.getJobDetail ^Scheduler scheduler (j/key group key))))
+     (.getJobDetail ^Scheduler scheduler (j/key key group))))
 
 (defn get-triggers-of-job
   "Returns a set of Trigger instances for the given collection of keys."

--- a/test/clojurewerkz/quartzite/test/simple_schedule_test.clj
+++ b/test/clojurewerkz/quartzite/test/simple_schedule_test.clj
@@ -39,6 +39,7 @@
     (sched/add-job s job1)
 
     (is (.equals (sched/get-job s jk) job1))
+    (is (.equals job1 (sched/get-job s job-group job-id)))
     (is (zero? (count (sched/get-triggers-of-job s jk))))
     (sched/shutdown s)))
 


### PR DESCRIPTION
`(get-job group key)` always returned null for me because the (j/key) call had the parameters reversed.

This is one fix. It just corrects the call to `(j/key)`. Another would be to rearrange the parameter names in the `(get-job)` defn. That might actually make more sense given that it would preserve existing functionality and really just be a doc change.