### PR TITLE
#46 Fix reflection, clj-kondo issues/exports, bump deps, remove joda time dep

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,1 @@
+{:config-paths ["../resources/clj-kondo.exports/clojurewerkz/quartzite"]}

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ checkouts/*
 deploy.docs.sh
 target/*
 .nrepl*
+.clj-kondo/.cache
+.idea/
+*.iml
+.lsp/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: clojure
 script: lein all test
 jdk:
-  - oraclejdk8
+  - openjdk21
 branches:
   only:
     - master

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,12 @@
 ## Changes Between Quartzite 2.2.0 and 2.3.0
 
-No changes yet.
+GitHub issue: [#46](https://github.com/michaelklishin/quartzite/issues/46)
+Add clj-kondo support and address lint issues
+Remove direct dependency on clj-time/Joda Time (DateConversion protocol is still extended if Joda Time is on the 
+classpath)
+Add support for Quartz 2.4.0 and Clojure 1.12.0
+
+Contributed by @vincentjames501.
 
 
 ## Changes Between Quartzite 2.1.0 and 2.2.0

--- a/project.clj
+++ b/project.clj
@@ -2,9 +2,10 @@
   :description "Quarzite is a thin Clojure layer on top the Quartz Scheduler"
   :min-lein-version "2.5.1"
   :license {:name "Eclipse Public License"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
-                 [org.quartz-scheduler/quartz "2.3.2"]
-                 [clj-time "0.14.2"]]
+  :dependencies [[org.clojure/clojure "1.12.0"]
+                 ;; 2.5.0 Has a bug that should be fixed before
+                 ;; updating https://github.com/quartz-scheduler/quartz/issues/1298
+                 [org.quartz-scheduler/quartz "2.4.0"]]
   :source-paths ["src/clojure"]
   :java-source-paths ["src/java"]
   :test-selectors {:all     (constantly true)
@@ -12,11 +13,14 @@
                    :default (constantly true)}
   :profiles {:1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
-             :master {:dependencies [[org.clojure/clojure "1.10.0-master-SNAPSHOT"]]}
-             :dev {:resource-paths ["test/resources"]
-                   :dependencies [[org.clojure/tools.logging "0.2.3" :exclusions [org.clojure/clojure]]
-                                  [org.slf4j/slf4j-log4j12   "1.6.4"]]}}
-  :aliases {"all" ["with-profile" "dev:dev,1.7:dev,master"]}
+             :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
+             :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}
+             :1.11 {:dependencies [[org.clojure/clojure "1.11.4"]]}
+             :1.12 {:dependencies [[org.clojure/clojure "1.12.0"]]}
+             :dev {:resource-paths ["test/resources" "resources"]
+                   :dependencies [[org.clojure/tools.logging "1.3.0" :exclusions [org.clojure/clojure]]
+                                  [org.slf4j/slf4j-log4j12   "2.0.16"]]}}
+  :aliases {"all" ["with-profile" "dev:dev,1.12:dev,master"]}
   :repositories {"sonatype" {:url "http://oss.sonatype.org/content/repositories/releases"
                              :snapshots false
                              :releases {:checksum :fail :update :always}}
@@ -27,6 +31,6 @@
   :mailing-list {:name "clojure-quartz"
                  :archive "https://groups.google.com/group/clojure-quartz"
                  :post "clojure-quartz@googlegroups.com"}
-  :plugins [[codox "0.8.10"]]
+  :plugins [[codox "0.10.8"]]
   :codox {:sources ["src/clojure"]
           :output-dir "doc/api"})

--- a/resources/clj-kondo.exports/clojurewerkz/quartzite/clj_kondo/clojurewerkz/quartzite.clj
+++ b/resources/clj-kondo.exports/clojurewerkz/quartzite/clj_kondo/clojurewerkz/quartzite.clj
@@ -1,0 +1,24 @@
+(ns clj-kondo.clojurewerkz.quartzite
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn threaded* [builder-sym final-sym {:keys [node]}]
+  (let [body (rest (:children node))]
+    (let [new-node (api/list-node
+                    (list*
+                     (api/token-node '->)
+                     (concat (when builder-sym
+                               [(api/token-node builder-sym)])
+                             body
+                             (when final-sym
+                               [(api/token-node final-sym)]))))]
+      {:node new-node})))
+
+(defn triggers-build [ctx]
+  (threaded* '(org.quartz.TriggerBuilder/newTrigger)
+             '(clojurewerkz.quartzite.triggers/finalize)
+             ctx))
+
+(defn jobs-build [ctx]
+  (threaded* '(org.quartz.JobBuilder/newJob)
+             '(clojurewerkz.quartzite.jobs/finalize)
+             ctx))

--- a/resources/clj-kondo.exports/clojurewerkz/quartzite/config.edn
+++ b/resources/clj-kondo.exports/clojurewerkz/quartzite/config.edn
@@ -1,0 +1,8 @@
+{:lint-as {clojurewerkz.quartzite.jobs/defjob clojure.core/defn
+           clojurewerkz.quartzite.stateful/def-stateful-job clojure.core/defn}
+ :hooks   {:analyze-call {
+
+
+                          clojurewerkz.quartzite.jobs/build clj-kondo.clojurewerkz.quartzite/jobs-build
+                          clojurewerkz.quartzite.triggers/build clj-kondo.clojurewerkz.quartzite/triggers-build
+                          }}}

--- a/src/clojure/clojurewerkz/quartzite/conversion.clj
+++ b/src/clojure/clojurewerkz/quartzite/conversion.clj
@@ -9,11 +9,11 @@
 
 (ns clojurewerkz.quartzite.conversion
   (:refer-clojure :exclude [key])
-  (:import [org.quartz JobDataMap JobExecutionContext]
-           org.quartz.utils.Key
-           [org.quartz TriggerKey JobKey]
-           clojure.lang.IPersistentMap
-           [org.quartz JobDetail Trigger]))
+  (:import (clojure.lang IPersistentMap)
+           (java.time Instant LocalDate LocalDateTime OffsetDateTime ZoneId ZonedDateTime)
+           (java.util Calendar Date)
+           (org.quartz JobDataMap JobExecutionContext JobDetail Trigger TriggerKey JobKey)
+           (org.quartz.utils Key)))
 
 ;;
 ;; Implementation
@@ -34,13 +34,13 @@
 
 ;; Monger and other ClojureWerkz project integration extension point. MK.
 (defprotocol JobDataMapConversion
-  (^org.quartz.JobDataMap
+  (^JobDataMap
     to-job-data   [input] "Instantiates a JobDataMap instance from a Clojure map")
   (from-job-data [input] "Converts a JobDataMap to a Clojure map"))
 
 (extend-protocol JobDataMapConversion
   IPersistentMap
-  (to-job-data [^clojure.lang.IPersistentMap input]
+  (to-job-data [^IPersistentMap input]
     (JobDataMap. (convert-keys-to-strings input)))
 
 
@@ -81,36 +81,67 @@
   (to-date [input] "Converts given input to java.util.Date"))
 
 (extend-protocol DateConversion
-  java.util.Date
+  Date
   (to-date [input]
     input)
 
-  ;; common cases
-  org.joda.time.DateTime
-  (to-date [input]
-    (.toDate input))
-  org.joda.time.MutableDateTime
-  (to-date [input]
-    (.toDate input))
+  Calendar
+  (to-date [^Calendar input]
+    (.getTime input))
 
-  ;; catch-all for Joda Date types convertable to java.util.Date
-  org.joda.time.base.BaseDateTime
-  (to-date [input]
-    (.toDate input)))
+  Instant
+  (to-date [^Instant input]
+    (Date/from input))
 
+  OffsetDateTime
+  (to-date [^OffsetDateTime input]
+    (Date/from (.toInstant input)))
+
+  ZonedDateTime
+  (to-date [^ZonedDateTime input]
+    (Date/from (.toInstant input)))
+
+  LocalDateTime
+  (to-date [^LocalDateTime input]
+    (Date/from (.toInstant ^ZonedDateTime (.atZone input ZoneId/systemDefault))))
+
+  LocalDate
+  (to-date [^LocalDate input]
+    (Date/from (.toInstant ^ZonedDateTime (.atStartOfDay input ZoneId/systemDefault)))))
+
+;; Dynamically load Joda time support if possible
+(defn class-exists? [sym]
+  (try
+    (boolean (resolve sym))
+    (catch Throwable _ false)))
+
+(when (every? class-exists? ['org.joda.time.DateTime
+                             'org.joda.time.MutableDateTime
+                             'org.joda.time.base.BaseDateTime])
+  (eval
+   `(extend-protocol DateConversion
+      org.joda.time.DateTime
+      (to-date [^org.joda.time.DateTime input#]
+        (.toDate input#))
+      org.joda.time.MutableDateTime
+      (to-date [^org.joda.time.MutableDateTime input#]
+        (.toDate input#))
+      org.joda.time.base.BaseDateTime
+      (to-date [^org.joda.time.base.BaseDateTime input#]
+        (.toDate input#)))))
 
 (defprotocol KeyCoercion
-  (^org.quartz.TriggerKey
+  (^TriggerKey
     to-trigger-key [input] "Converts a key to a TriggerKey instance")
-  (^org.quartz.JobKey
+  (^JobKey
     to-job-key [input] "Converts a key to a JobKey instance"))
 
 (extend-protocol KeyCoercion
-  org.quartz.TriggerKey
+  TriggerKey
   (to-trigger-key [input]
     input)
 
-  org.quartz.JobKey
+  JobKey
   (to-job-key [input]
     input)
 

--- a/src/clojure/clojurewerkz/quartzite/jobs.clj
+++ b/src/clojure/clojurewerkz/quartzite/jobs.clj
@@ -9,9 +9,8 @@
 
 (ns clojurewerkz.quartzite.jobs
   (:refer-clojure :exclude [key])
-  (:import [org.quartz Job JobDetail JobBuilder JobKey JobExecutionContext JobDataMap]
-           [org.quartz.utils Key]
-           [clojure.lang IPersistentMap])
+  (:import (org.quartz Job JobDetail JobBuilder JobKey)
+           (org.quartz.utils Key))
   (:require    [clojurewerkz.quartzite.conversion :refer [to-job-data]]))
 
 
@@ -27,50 +26,50 @@
 ;; API
 ;;
 
-(defn ^JobKey key
-  ([]
+(defn key
+  (^JobKey []
      (JobKey. (Key/createUniqueName nil)))
-  ([named]
+  (^JobKey [named]
      (JobKey. (name named)))
-  ([named, group]
+  (^JobKey [named, group]
      (JobKey. (name named) (name group))))
 
 
 
-(defn ^JobBuilder with-identity
-  ([^JobBuilder jb s]
+(defn with-identity
+  (^JobBuilder [^JobBuilder jb s]
      (if (instance? JobKey s)
        (.withIdentity jb ^JobKey s)
        (.withIdentity jb (key s))))
-  ([^JobBuilder jb s group]
+  (^JobBuilder [^JobBuilder jb s group]
      (.withIdentity jb (key s group))))
 
-(defn ^JobBuilder with-description
-  [^JobBuilder jb ^String s]
+(defn with-description
+  ^JobBuilder [^JobBuilder jb ^String s]
   (.withDescription jb s))
 
-(defn ^JobBuilder store-durably
-  [^JobBuilder jb]
+(defn store-durably
+  ^JobBuilder [^JobBuilder jb]
   (.storeDurably jb))
 
-(defn ^JobBuilder request-recovery
-  [^JobBuilder jb]
+(defn request-recovery
+  ^JobBuilder [^JobBuilder jb]
   (.requestRecovery jb))
 
-(defn ^JobBuilder of-type
-  [^JobBuilder jb clazz]
+(defn of-type
+  ^JobBuilder [^JobBuilder jb clazz]
   (.ofType jb clazz))
 
-(defn ^JobBuilder using-job-data
-  [^JobBuilder tb m]
+(defn using-job-data
+  ^JobBuilder [^JobBuilder tb m]
   (.usingJobData tb (to-job-data m)))
 
-(defn ^JobDetail finalize
-  [^JobBuilder jb]
+(defn finalize
+  ^JobDetail [^JobBuilder jb]
   (.build jb))
 
 
-(defmacro ^JobDetail build
+(defmacro build
   [& body]
   `(let [jb# (JobBuilder/newJob)]
      (finalize (-> jb# ~@body))))
@@ -81,6 +80,6 @@
 (defmacro defjob
   [jtype args & body]
   `(defrecord ~jtype []
-       org.quartz.Job
+       Job
      (execute [this ~@args]
        ~@body)))

--- a/src/clojure/clojurewerkz/quartzite/matchers.clj
+++ b/src/clojure/clojurewerkz/quartzite/matchers.clj
@@ -10,8 +10,8 @@
 (ns clojurewerkz.quartzite.matchers
   "Contains factory functions that produce group matchers.
    Group matchers are used to retrieve triggers and jobs from the scheduler en masse."
-  (:import org.quartz.impl.matchers.GroupMatcher
-           org.quartz.utils.Key))
+  (:import (org.quartz.impl.matchers GroupMatcher)
+           (org.quartz.utils Key)))
 
 
 ;;
@@ -23,26 +23,22 @@
   [^GroupMatcher matcher ^Key key]
   (.isMatch matcher key))
 
-(defn ^org.quartz.impl.matchers.GroupMatcher
-  group-equals
+(defn group-equals
   "Returns a group matcher that matches keys in the given group"
-  [^String s]
+  ^GroupMatcher [^String s]
   (GroupMatcher/groupEquals s))
 
-(defn ^org.quartz.impl.matchers.GroupMatcher
-  group-starts-with
+(defn group-starts-with
   "Returns a group matcher that matches keys in all groups that start with the given prefix"
-  [^String s]
+  ^GroupMatcher [^String s]
   (GroupMatcher/groupStartsWith s))
 
-(defn ^org.quartz.impl.matchers.GroupMatcher
-  group-ends-with
+(defn group-ends-with
   "Returns a group matcher that matches keys in all groups that end with the given suffix"
-  [^String s]
+  ^GroupMatcher [^String s]
   (GroupMatcher/groupEndsWith s))
 
-(defn ^org.quartz.impl.matchers.GroupMatcher
-  group-contains
+(defn group-contains
   "Returns a group matcher that matches keys in all groups that contain the given substring"
-  [^String s]
+  ^GroupMatcher [^String s]
   (GroupMatcher/groupContains s))

--- a/src/clojure/clojurewerkz/quartzite/schedule/calendar_interval.clj
+++ b/src/clojure/clojurewerkz/quartzite/schedule/calendar_interval.clj
@@ -8,61 +8,62 @@
 ;; You must not remove this notice, or any other, from this software.
 
 (ns clojurewerkz.quartzite.schedule.calendar-interval
-  (:import [org.quartz CalendarIntervalScheduleBuilder DateBuilder]))
+  (:import (org.quartz CalendarIntervalScheduleBuilder)
+           (org.quartz.spi MutableTrigger)))
 
 
 (defn with-interval-in-seconds
-  [^CalendarIntervalScheduleBuilder cisb ^long seconds]
+  ^CalendarIntervalScheduleBuilder [^CalendarIntervalScheduleBuilder cisb ^long seconds]
   (.withIntervalInSeconds cisb seconds))
 
 (defn with-interval-in-minutes
-  [^CalendarIntervalScheduleBuilder cisb ^long minutes]
+  ^CalendarIntervalScheduleBuilder [^CalendarIntervalScheduleBuilder cisb ^long minutes]
   (.withIntervalInMinutes cisb minutes))
 
 (defn with-interval-in-hours
-  [^CalendarIntervalScheduleBuilder cisb ^long hours]
+  ^CalendarIntervalScheduleBuilder [^CalendarIntervalScheduleBuilder cisb ^long hours]
   (.withIntervalInHours cisb hours))
 
 (defn with-interval-in-days
-  [^CalendarIntervalScheduleBuilder cisb ^long days]
+  ^CalendarIntervalScheduleBuilder [^CalendarIntervalScheduleBuilder cisb ^long days]
   (.withIntervalInDays cisb days))
 
 (defn with-interval-in-weeks
-  [^CalendarIntervalScheduleBuilder cisb ^long weeks]
+  ^CalendarIntervalScheduleBuilder [^CalendarIntervalScheduleBuilder cisb ^long weeks]
   (.withIntervalInWeeks cisb weeks))
 
 (defn with-interval-in-months
-  [^CalendarIntervalScheduleBuilder cisb ^long months]
+  ^CalendarIntervalScheduleBuilder [^CalendarIntervalScheduleBuilder cisb ^long months]
   (.withIntervalInMonths cisb months))
 
 (defn with-interval-in-years
-  [^CalendarIntervalScheduleBuilder cisb ^long years]
+  ^CalendarIntervalScheduleBuilder [^CalendarIntervalScheduleBuilder cisb ^long years]
   (.withIntervalInYears cisb years))
 
 
 
 
 (defn with-misfire-handling-instruction-ignore-misfires
-  [^CalendarIntervalScheduleBuilder cisb]
+  ^CalendarIntervalScheduleBuilder [^CalendarIntervalScheduleBuilder cisb]
   (.withMisfireHandlingInstructionIgnoreMisfires cisb))
 
 (defn ignore-misfires
-  [^CalendarIntervalScheduleBuilder cisb]
+  ^CalendarIntervalScheduleBuilder [^CalendarIntervalScheduleBuilder cisb]
   (.withMisfireHandlingInstructionIgnoreMisfires cisb))
 
 (defn with-misfire-handling-instruction-do-nothing
-  [^CalendarIntervalScheduleBuilder cisb]
+  ^CalendarIntervalScheduleBuilder [^CalendarIntervalScheduleBuilder cisb]
   (.withMisfireHandlingInstructionDoNothing cisb))
 
 
 (defn with-misfire-handling-instruction-fire-and-proceed
-  [^CalendarIntervalScheduleBuilder cisb]
+  ^CalendarIntervalScheduleBuilder [^CalendarIntervalScheduleBuilder cisb]
   (.withMisfireHandlingInstructionFireAndProceed cisb))
 
 
 
 (defn finalize
-  [^CalendarIntervalScheduleBuilder cisb]
+  ^MutableTrigger [^CalendarIntervalScheduleBuilder cisb]
   (.build cisb))
 
 (defmacro schedule

--- a/src/clojure/clojurewerkz/quartzite/schedule/cron.clj
+++ b/src/clojure/clojurewerkz/quartzite/schedule/cron.clj
@@ -8,56 +8,56 @@
 ;; You must not remove this notice, or any other, from this software.
 
 (ns clojurewerkz.quartzite.schedule.cron
-  (:import [org.quartz CronScheduleBuilder]
-           [org.quartz.spi MutableTrigger]
-           [java.util TimeZone]))
+  (:import (org.quartz CronScheduleBuilder)
+           (java.util TimeZone)
+           (org.quartz.spi MutableTrigger)))
 
 
 (defn cron-schedule
-  [^String expression]
+  ^CronScheduleBuilder [^String expression]
   (CronScheduleBuilder/cronSchedule expression))
 
 (defn daily-at-hour-and-minute
-  [^long hour ^long minute]
+  ^CronScheduleBuilder [^long hour ^long minute]
   (CronScheduleBuilder/dailyAtHourAndMinute hour minute))
 
 (defn weekly-on-day-and-hour-and-minute
-  [^long day-of-week ^long hour ^long minute]
+  ^CronScheduleBuilder [^long day-of-week ^long hour ^long minute]
   (CronScheduleBuilder/weeklyOnDayAndHourAndMinute day-of-week hour minute))
 
 (defn monthly-on-day-and-hour-and-minute
-  [^long day-of-month ^long hour ^long minute]
+  ^CronScheduleBuilder [^long day-of-month ^long hour ^long minute]
   (CronScheduleBuilder/monthlyOnDayAndHourAndMinute day-of-month hour minute))
 
 
 (defn in-time-zone
-  [^CronScheduleBuilder ssb ^TimeZone tz]
+  ^CronScheduleBuilder  [^CronScheduleBuilder ssb ^TimeZone tz]
   (.inTimeZone ssb tz))
 
 
 (defn with-misfire-handling-instruction-ignore-misfires
-  [^CronScheduleBuilder ssb]
+  ^CronScheduleBuilder [^CronScheduleBuilder ssb]
   (.withMisfireHandlingInstructionIgnoreMisfires ssb))
 
 (defn ignore-misfires
-  [^CronScheduleBuilder ssb]
+  ^CronScheduleBuilder [^CronScheduleBuilder ssb]
   (.withMisfireHandlingInstructionIgnoreMisfires ssb))
 
 (defn with-misfire-handling-instruction-do-nothing
-  [^CronScheduleBuilder ssb]
+  ^CronScheduleBuilder [^CronScheduleBuilder ssb]
   (.withMisfireHandlingInstructionDoNothing ssb))
 
 (defn with-misfire-handling-instruction-fire-and-proceed
-  [^CronScheduleBuilder ssb]
+  ^CronScheduleBuilder [^CronScheduleBuilder ssb]
   (.withMisfireHandlingInstructionFireAndProceed ssb))
 
 (defn fire-and-proceed
-  [^CronScheduleBuilder ssb]
+  ^CronScheduleBuilder [^CronScheduleBuilder ssb]
   (.withMisfireHandlingInstructionFireAndProceed ssb))
 
 
 (defn finalize
-  [^CronScheduleBuilder ssb]
+  ^MutableTrigger [^CronScheduleBuilder ssb]
   (.build ssb))
 
 (defmacro schedule

--- a/src/clojure/clojurewerkz/quartzite/schedule/daily_interval.clj
+++ b/src/clojure/clojurewerkz/quartzite/schedule/daily_interval.clj
@@ -8,103 +8,104 @@
 ;; You must not remove this notice, or any other, from this software.
 
 (ns clojurewerkz.quartzite.schedule.daily-interval
-  (:import [org.quartz DailyTimeIntervalScheduleBuilder DateBuilder TimeOfDay]
-           [java.util Set]))
+  (:import (org.quartz DailyTimeIntervalScheduleBuilder TimeOfDay)
+           (java.util Set)
+           (org.quartz.spi MutableTrigger)))
 
 (defn with-interval-in-seconds
-  [^DailyTimeIntervalScheduleBuilder dtisb ^long seconds]
+  ^DailyTimeIntervalScheduleBuilder [^DailyTimeIntervalScheduleBuilder dtisb ^long seconds]
   (.withIntervalInSeconds dtisb seconds))
 
 (defn with-interval-in-minutes
-  [^DailyTimeIntervalScheduleBuilder dtisb ^long minutes]
+  ^DailyTimeIntervalScheduleBuilder [^DailyTimeIntervalScheduleBuilder dtisb ^long minutes]
   (.withIntervalInMinutes dtisb minutes))
 
 (defn with-interval-in-hours
-  [^DailyTimeIntervalScheduleBuilder dtisb ^long hours]
+  ^DailyTimeIntervalScheduleBuilder [^DailyTimeIntervalScheduleBuilder dtisb ^long hours]
   (.withIntervalInHours dtisb hours))
 
 (defn with-interval-in-days
-  [^DailyTimeIntervalScheduleBuilder dtisb ^long days]
+  ^DailyTimeIntervalScheduleBuilder [^DailyTimeIntervalScheduleBuilder dtisb ^long days]
   (.withIntervalInHours dtisb (* 24 days)))
 
 
 (defn with-repeat-count
-  [^DailyTimeIntervalScheduleBuilder dtisb ^long l]
+  ^DailyTimeIntervalScheduleBuilder [^DailyTimeIntervalScheduleBuilder dtisb ^long l]
   (.withRepeatCount dtisb l))
 
 
 (defn on-every-day
-  [^DailyTimeIntervalScheduleBuilder dtisb]
+  ^DailyTimeIntervalScheduleBuilder [^DailyTimeIntervalScheduleBuilder dtisb]
   (.onEveryDay dtisb))
 
 (defn every-day
-  [^DailyTimeIntervalScheduleBuilder dtisb]
+  ^DailyTimeIntervalScheduleBuilder [^DailyTimeIntervalScheduleBuilder dtisb]
   (on-every-day dtisb))
 
 
 
 (defn on-days-of-the-week
-  [^DailyTimeIntervalScheduleBuilder dtisb ^Set days]
+  ^DailyTimeIntervalScheduleBuilder [^DailyTimeIntervalScheduleBuilder dtisb ^Set days]
   (.onDaysOfTheWeek dtisb days))
 
 (defn days-of-the-week
-  [^DailyTimeIntervalScheduleBuilder dtisb ^Set days]
+  ^DailyTimeIntervalScheduleBuilder [^DailyTimeIntervalScheduleBuilder dtisb ^Set days]
   (on-days-of-the-week dtisb days))
 
 
 
 (defn on-monday-through-friday
-  [^DailyTimeIntervalScheduleBuilder dtisb]
+  ^DailyTimeIntervalScheduleBuilder [^DailyTimeIntervalScheduleBuilder dtisb]
   (.onMondayThroughFriday dtisb))
 
 (defn monday-through-friday
-  [^DailyTimeIntervalScheduleBuilder dtisb]
+  ^DailyTimeIntervalScheduleBuilder [^DailyTimeIntervalScheduleBuilder dtisb]
   (on-monday-through-friday dtisb))
 
 
 (defn on-saturday-and-sunday
-  [^DailyTimeIntervalScheduleBuilder dtisb]
+  ^DailyTimeIntervalScheduleBuilder [^DailyTimeIntervalScheduleBuilder dtisb]
   (.onSaturdayAndSunday dtisb))
 
 (defn saturday-and-sunday
-  [^DailyTimeIntervalScheduleBuilder dtisb]
+  ^DailyTimeIntervalScheduleBuilder [^DailyTimeIntervalScheduleBuilder dtisb]
   (on-saturday-and-sunday dtisb))
 
 
 (defn time-of-day
-  [^long hours ^long minutes ^long seconds]
+  ^TimeOfDay [^long hours ^long minutes ^long seconds]
   (TimeOfDay. hours minutes seconds))
 
 (defn starting-daily-at
-  [^DailyTimeIntervalScheduleBuilder dtisb ^TimeOfDay at]
+  ^DailyTimeIntervalScheduleBuilder [^DailyTimeIntervalScheduleBuilder dtisb ^TimeOfDay at]
   (.startingDailyAt dtisb at))
 
 (defn ending-daily-at
-  [^DailyTimeIntervalScheduleBuilder dtisb ^TimeOfDay at]
+  ^DailyTimeIntervalScheduleBuilder [^DailyTimeIntervalScheduleBuilder dtisb ^TimeOfDay at]
   (.endingDailyAt dtisb at))
 
 
 
 (defn with-misfire-handling-instruction-ignore-misfires
-  [^DailyTimeIntervalScheduleBuilder dtisb]
+  ^DailyTimeIntervalScheduleBuilder [^DailyTimeIntervalScheduleBuilder dtisb]
   (.withMisfireHandlingInstructionIgnoreMisfires dtisb))
 
 (defn ignore-misfires
-  [^DailyTimeIntervalScheduleBuilder dtisb]
+  ^DailyTimeIntervalScheduleBuilder [^DailyTimeIntervalScheduleBuilder dtisb]
   (.withMisfireHandlingInstructionIgnoreMisfires dtisb))
 
 (defn with-misfire-handling-instruction-fire-and-proceed
-  [^DailyTimeIntervalScheduleBuilder dtisb]
+  ^DailyTimeIntervalScheduleBuilder [^DailyTimeIntervalScheduleBuilder dtisb]
   (.withMisfireHandlingInstructionFireAndProceed dtisb))
 
 (defn with-misfire-handling-instruction-do-nothing
-  [^DailyTimeIntervalScheduleBuilder cisb]
+  ^DailyTimeIntervalScheduleBuilder [^DailyTimeIntervalScheduleBuilder cisb]
   (.withMisfireHandlingInstructionDoNothing cisb))
 
 
 
 (defn finalize
-  [^DailyTimeIntervalScheduleBuilder dtisb]
+  ^MutableTrigger [^DailyTimeIntervalScheduleBuilder dtisb]
   (.build dtisb))
 
 (defmacro schedule

--- a/src/clojure/clojurewerkz/quartzite/schedule/simple.clj
+++ b/src/clojure/clojurewerkz/quartzite/schedule/simple.clj
@@ -8,91 +8,92 @@
 ;; You must not remove this notice, or any other, from this software.
 
 (ns clojurewerkz.quartzite.schedule.simple
-  (:import [org.quartz SimpleScheduleBuilder DateBuilder]))
+  (:import (org.quartz SimpleScheduleBuilder)
+           (org.quartz.spi MutableTrigger)))
 
 (defn with-interval-in-milliseconds
-  [^SimpleScheduleBuilder ssb ^long milliseconds]
+  ^SimpleScheduleBuilder [^SimpleScheduleBuilder ssb ^long milliseconds]
   (.withIntervalInMilliseconds ssb milliseconds))
 
 (defn with-interval-in-seconds
-  [^SimpleScheduleBuilder ssb ^long seconds]
+  ^SimpleScheduleBuilder [^SimpleScheduleBuilder ssb ^long seconds]
   (.withIntervalInSeconds ssb seconds))
 
 (defn with-interval-in-minutes
-  [^SimpleScheduleBuilder ssb ^long minutes]
+  ^SimpleScheduleBuilder [^SimpleScheduleBuilder ssb ^long minutes]
   (.withIntervalInMinutes ssb minutes))
 
 (defn with-interval-in-hours
-  [^SimpleScheduleBuilder ssb ^long hours]
+  ^SimpleScheduleBuilder [^SimpleScheduleBuilder ssb ^long hours]
   (.withIntervalInHours ssb hours))
 
 (defn with-interval-in-days
-  [^SimpleScheduleBuilder ssb ^long days]
+  ^SimpleScheduleBuilder [^SimpleScheduleBuilder ssb ^long days]
   (.withIntervalInHours ssb (* 24 days)))
 
 
 (defn with-repeat-count
-  [^SimpleScheduleBuilder ssb ^long l]
+  ^SimpleScheduleBuilder [^SimpleScheduleBuilder ssb ^long l]
   (.withRepeatCount ssb l))
 
 (defn repeat-forever
-  [^SimpleScheduleBuilder ssb]
+  ^SimpleScheduleBuilder [^SimpleScheduleBuilder ssb]
   (.repeatForever ssb))
 
 
 
 (defn with-misfire-handling-instruction-ignore-misfires
-  [^SimpleScheduleBuilder ssb]
+  ^SimpleScheduleBuilder [^SimpleScheduleBuilder ssb]
   (.withMisfireHandlingInstructionIgnoreMisfires ssb))
 
 (defn ignore-misfires
-  [^SimpleScheduleBuilder ssb]
+  ^SimpleScheduleBuilder [^SimpleScheduleBuilder ssb]
   (.withMisfireHandlingInstructionIgnoreMisfires ssb))
 
 (defn with-misfire-handling-instruction-fire-now
-  [^SimpleScheduleBuilder ssb]
+  ^SimpleScheduleBuilder [^SimpleScheduleBuilder ssb]
   (.withMisfireHandlingInstructionFireNow ssb))
 
 
 (defn with-misfire-handling-instruction-next-with-existing-count
-  [^SimpleScheduleBuilder ssb]
+  ^SimpleScheduleBuilder [^SimpleScheduleBuilder ssb]
   (.withMisfireHandlingInstructionNextWithExistingCount ssb))
 
 (defn next-with-existing-count
-  [^SimpleScheduleBuilder ssb]
+  ^SimpleScheduleBuilder [^SimpleScheduleBuilder ssb]
   (.withMisfireHandlingInstructionNextWithExistingCount ssb))
 
 
 (defn with-misfire-handling-instruction-next-with-remaining-count
-  [^SimpleScheduleBuilder ssb]
+  ^SimpleScheduleBuilder [^SimpleScheduleBuilder ssb]
   (.withMisfireHandlingInstructionNextWithRemainingCount ssb))
 
 (defn next-with-remaining-count
-  [^SimpleScheduleBuilder ssb]
+  ^SimpleScheduleBuilder [^SimpleScheduleBuilder ssb]
   (.withMisfireHandlingInstructionNextWithRemainingCount ssb))
 
 
 (defn with-misfire-handling-instruction-now-with-existing-count
-  [^SimpleScheduleBuilder ssb]
+  ^SimpleScheduleBuilder [^SimpleScheduleBuilder ssb]
   (.withMisfireHandlingInstructionNowWithExistingCount ssb))
 
 (defn now-with-existing-count
-  [^SimpleScheduleBuilder ssb]
+  ^SimpleScheduleBuilder [^SimpleScheduleBuilder ssb]
   (.withMisfireHandlingInstructionNowWithExistingCount ssb))
 
 
 (defn with-misfire-handling-instruction-now-with-remaining-count
-  [^SimpleScheduleBuilder ssb]
+  ^SimpleScheduleBuilder [^SimpleScheduleBuilder ssb]
   (.withMisfireHandlingInstructionNowWithRemainingCount ssb))
 
 (defn now-with-remaining-count
-  [^SimpleScheduleBuilder ssb]
+  ^SimpleScheduleBuilder [^SimpleScheduleBuilder ssb]
   (.withMisfireHandlingInstructionNowWithRemainingCount ssb))
 
 
 
 (defn finalize
-  [^SimpleScheduleBuilder ssb]
+  ^MutableTrigger [^SimpleScheduleBuilder ssb]
   (.build ssb))
 
 (defmacro schedule

--- a/src/clojure/clojurewerkz/quartzite/scheduler.clj
+++ b/src/clojure/clojurewerkz/quartzite/scheduler.clj
@@ -8,34 +8,33 @@
 ;; You must not remove this notice, or any other, from this software.
 
 (ns clojurewerkz.quartzite.scheduler
-  (:import [org.quartz Scheduler JobDetail JobKey Trigger TriggerKey SchedulerListener ListenerManager JobExecutionContext]
-           org.quartz.impl.matchers.GroupMatcher
-           java.util.List)
   (:require [clojurewerkz.quartzite.jobs :as j]
             [clojurewerkz.quartzite.triggers :as t]
-            [clojurewerkz.quartzite.conversion :refer :all]))
-
-(set! *warn-on-reflection* true)
+            [clojurewerkz.quartzite.conversion :refer [to-job-key]])
+  (:import (java.util Date List)
+           (org.quartz Scheduler JobDetail JobKey Trigger TriggerKey SchedulerListener ListenerManager JobExecutionContext)
+           (org.quartz.impl.matchers GroupMatcher)
+           (org.quartz.impl StdSchedulerFactory)))
 
 ;;
 ;; API
 ;;
 
-(defn ^Scheduler initialize
+(defn initialize
   "Initializes a scheduler."
-  []
-  (org.quartz.impl.StdSchedulerFactory/getDefaultScheduler))
+  ^Scheduler []
+  (StdSchedulerFactory/getDefaultScheduler))
 
-(defn ^Scheduler start
+(defn start
   "Starts Quartzite's scheduler. Newly initialized scheduler is not active (in standby mode),
    this function starts it"
-  [^Scheduler scheduler]
+  ^Scheduler [^Scheduler scheduler]
   (doto scheduler
     .start))
 
-(defn ^Scheduler start-delayed
+(defn start-delayed
   "Starts Quartzite's scheduler after a delay in seconds"
-  [^Scheduler scheduler ^long seconds]
+  ^Scheduler [^Scheduler scheduler ^long seconds]
   (doto scheduler
     (.startDelayed seconds)))
 
@@ -70,7 +69,7 @@
 (defn schedule
   "Adds given job to the scheduler and associates it with given trigger.
    Trigger controls job execution schedule, initial execution time and other characteristics"
-  [^Scheduler scheduler ^JobDetail job-detail ^Trigger trigger]
+  ^Date [^Scheduler scheduler ^JobDetail job-detail ^Trigger trigger]
   (.scheduleJob ^Scheduler scheduler job-detail trigger))
 
 (defn add-job
@@ -83,7 +82,7 @@
 
 (defn add-trigger
   "Adds given trigger to the scheduled job with which the trigger has been associated"
-  [^Scheduler scheduler ^Trigger trigger]
+  ^Date [^Scheduler scheduler ^Trigger trigger]
   (.scheduleJob ^Scheduler scheduler trigger))
 
 
@@ -179,16 +178,16 @@
 
 (defn get-trigger
   "Returns a Trigger instance for the given key."
-  ([^Scheduler scheduler key]
+  (^Trigger [^Scheduler scheduler key]
      (.getTrigger ^Scheduler scheduler key))
-  ([^Scheduler scheduler ^String group ^String key]
+  (^Trigger [^Scheduler scheduler ^String group ^String key]
      (.getTrigger ^Scheduler scheduler (t/key key group))))
 
 (defn get-job
   "Returns a JobDetail instance for the given key."
-  ([^Scheduler scheduler key]
+  (^JobDetail [^Scheduler scheduler key]
      (.getJobDetail ^Scheduler scheduler (to-job-key key)))
-  ([^Scheduler scheduler ^String group ^String key]
+  (^JobDetail [^Scheduler scheduler ^String group ^String key]
      (.getJobDetail ^Scheduler scheduler (j/key key group))))
 
 (defn get-triggers-of-job
@@ -212,7 +211,7 @@
 (defn get-currently-executing-jobs
   "Returns a set of JobExecutionContext that represent the currently executing jobs for a given key"
   [^Scheduler scheduler key]
-  (filter #(= (.. ^JobExecutionContext % getJobDetail getKey) (j/key key))
+  (filter #(= (.getKey (.getJobDetail ^JobExecutionContext %)) (j/key key))
           (.getCurrentlyExecutingJobs ^Scheduler scheduler)))
 
 (defn currently-executing-job?
@@ -251,7 +250,9 @@
 (defn scheduled?
   "Checks if entity with given key already exists within the scheduler"
   [^Scheduler scheduler key]
-  (.checkExists scheduler key))
+  (if (instance? JobKey key)
+    (.checkExists scheduler ^JobKey key)
+    (.checkExists scheduler ^TriggerKey key)))
 
 (defn all-scheduled?
   "Returns true if all provided keys (trigger or job) are scheduled"

--- a/src/clojure/clojurewerkz/quartzite/stateful.clj
+++ b/src/clojure/clojurewerkz/quartzite/stateful.clj
@@ -8,22 +8,23 @@
 ;; You must not remove this notice, or any other, from this software.
 
 (ns clojurewerkz.quartzite.stateful
-  (:import [org.quartz JobExecutionContext])
-  (:require [clojurewerkz.quartzite.conversion :as conv]))
+  (:require [clojurewerkz.quartzite.conversion :as conv])
+  (:import (org.quartz JobExecutionContext StatefulJob)))
 
 (defmacro def-stateful-job
   "Just like clojurewerkz.quartzite.jobs/defjob but defines a stateful job"
   [jtype args & body]
   `(defrecord ~jtype []
-     org.quartz.StatefulJob
+     StatefulJob
      (execute [this ~@args]
        ~@body)))
 
 (defn replace!
   "Replaces the job data of the current context execution for the map m, so it will be persisted. Returns m."
   [^JobExecutionContext ctx m]
-  (.. ctx getJobDetail getJobDataMap clear)
-  (.. ctx getJobDetail getJobDataMap (putAll m))
+  (let [jdm (.getJobDataMap (.getJobDetail ctx))]
+    (.clear jdm)
+    (.putAll jdm m))
   m)
 
 (defn get-job-detail-data

--- a/src/clojure/clojurewerkz/quartzite/triggers.clj
+++ b/src/clojure/clojurewerkz/quartzite/triggers.clj
@@ -9,12 +9,9 @@
 
 (ns clojurewerkz.quartzite.triggers
   (:refer-clojure :exclude [key])
-  (:import [org.quartz Trigger TriggerBuilder TriggerKey ScheduleBuilder]
-           org.quartz.utils.Key
-           java.util.Date)
-  (:require    [clojurewerkz.quartzite.conversion :refer [to-job-data to-date]]))
-
-(set! *warn-on-reflection* true)
+  (:require    [clojurewerkz.quartzite.conversion :refer [to-job-data to-date]])
+  (:import (org.quartz JobDetail JobKey Trigger TriggerBuilder TriggerKey ScheduleBuilder)
+           (org.quartz.utils Key)))
 
 ;;
 ;; Implementation
@@ -28,77 +25,79 @@
 ;; API
 ;;
 
-(defn ^TriggerKey key
-  ([]
+(defn key
+  (^TriggerKey []
      (TriggerKey. (Key/createUniqueName nil)))
-  ([named]
+  (^TriggerKey [named]
      (TriggerKey. (name named)))
-  ([named, group]
+  (^TriggerKey [named, group]
      (TriggerKey. (name named) (name group))))
 
 
 
-(defn ^TriggerBuilder with-identity
-  ([^TriggerBuilder tb s]
+(defn with-identity
+  (^TriggerBuilder [^TriggerBuilder tb s]
      (if (instance? TriggerKey s)
        (.withIdentity tb ^TriggerKey s)
        (.withIdentity tb (key s))))
-  ([^TriggerBuilder tb s group]
+  (^TriggerBuilder [^TriggerBuilder tb s group]
      (.withIdentity tb (key s group))))
 
-(defn ^TriggerBuilder with-description
-  [^TriggerBuilder tb ^String s]
+(defn with-description
+  ^TriggerBuilder [^TriggerBuilder tb ^String s]
   (.withDescription tb s))
 
 
-(defn ^TriggerBuilder with-priority
-  [^TriggerBuilder tb ^long l]
+(defn with-priority
+  ^TriggerBuilder [^TriggerBuilder tb ^long l]
   (.withPriority tb l))
 
-(defn ^TriggerBuilder modified-by-calendar
-  [^TriggerBuilder tb ^String s]
+(defn modified-by-calendar
+  ^TriggerBuilder [^TriggerBuilder tb ^String s]
   (.modifiedByCalendar tb s))
 
-(defn ^TriggerBuilder with-schedule
-  [^TriggerBuilder tb ^ScheduleBuilder sb]
+(defn with-schedule
+  ^TriggerBuilder [^TriggerBuilder tb ^ScheduleBuilder sb]
   (.withSchedule tb sb))
 
-(defn ^TriggerBuilder start-now
-  [^TriggerBuilder tb]
+(defn start-now
+  ^TriggerBuilder [^TriggerBuilder tb]
   (.startNow tb))
 
 
 ;; Seamless JodaTime integration is one
 ;; of the goals of Quartzite.
 (defn start-at
-  [^TriggerBuilder tb date]
+  ^TriggerBuilder [^TriggerBuilder tb date]
   (.startAt tb (to-date date)))
 
 (defn end-at
-  [^TriggerBuilder tb date]
+  ^TriggerBuilder [^TriggerBuilder tb date]
   (.endAt tb (to-date date)))
 
 
 
 (defn for-job
-  ([^TriggerBuilder tb job]
-     (.forJob tb job))
-  ([^TriggerBuilder tb job group]
+  (^TriggerBuilder [^TriggerBuilder tb job]
+   (cond (string? job) (.forJob tb ^String job)
+         (instance? JobKey job) (.forJob tb ^JobKey job)
+         :else (.forJob tb ^JobDetail job)))
+  (^TriggerBuilder [^TriggerBuilder tb ^String job ^String group]
      (.forJob tb job group)))
 
 
-(defn ^TriggerBuilder using-job-data
-  [^TriggerBuilder tb m]
+(defn using-job-data
+  ^TriggerBuilder [^TriggerBuilder tb m]
   (.usingJobData tb (to-job-data m)))
 
 
 
-(defn ^Trigger finalize
-  [^TriggerBuilder tb]
+(defn finalize
+  ^Trigger [^TriggerBuilder tb]
   (.build tb))
 
 
-(defmacro ^Trigger build
+(defmacro build
   [& body]
   `(let [tb# (TriggerBuilder/newTrigger)]
      (finalize (-> tb# ~@body))))

--- a/test/clojurewerkz/quartzite/test/conversion_test.clj
+++ b/test/clojurewerkz/quartzite/test/conversion_test.clj
@@ -1,6 +1,6 @@
-(ns clojurewerkz.quartzite.test.stateful-test
-  (:require [clojure.test :refer :all]
-            [clojurewerkz.quartzite.conversion :refer :all]))
+(ns clojurewerkz.quartzite.test.conversion-test
+  (:require [clojure.test :refer [are deftest]]
+            [clojurewerkz.quartzite.conversion :refer [from-job-data to-job-data]]))
 
 (defrecord Abc [a b c])
 

--- a/test/clojurewerkz/quartzite/test/execution_test.clj
+++ b/test/clojurewerkz/quartzite/test/execution_test.clj
@@ -5,11 +5,14 @@
             [clojurewerkz.quartzite.matchers  :as m]
             [clojurewerkz.quartzite.schedule.simple :as s]
             [clojurewerkz.quartzite.schedule.calendar-interval :as calin]
-            [clojure.test :refer :all]
-            [clojurewerkz.quartzite.conversion :refer :all]
-            [clj-time.core :refer [now seconds from-now]])
-  (:import java.util.concurrent.CountDownLatch
-           org.quartz.impl.matchers.GroupMatcher))
+            [clojure.test :refer [deftest is]]
+            [clojurewerkz.quartzite.conversion :refer [from-job-data from-job-detail from-trigger]])
+  (:import (java.time Instant)
+           (java.time.temporal ChronoUnit)
+           (java.util Date)
+           (java.util.concurrent CountDownLatch)
+           (org.quartz Job ObjectAlreadyExistsException)
+           (org.quartz.impl.matchers GroupMatcher)))
 
 ;;
 ;; Case 1
@@ -18,8 +21,8 @@
 (def latch1 (CountDownLatch. 10))
 
 (defrecord JobA []
-  org.quartz.Job
-  (execute [this ctx]
+  Job
+  (execute [_this _ctx]
     (.countDown ^CountDownLatch latch1)))
 
 (deftest ^:focus test-basic-periodic-execution-with-a-job-defined-using-defrecord
@@ -54,7 +57,7 @@
 (def counter2 (atom 0))
 
 (j/defjob JobB
-  [ctx]
+  [_ctx]
   (swap! counter2 inc))
 
 (deftest test-unscheduling-of-a-job-defined-using-defjob
@@ -73,8 +76,8 @@
                                     (s/with-interval-in-milliseconds 400))))]
     (sched/schedule s job trigger)
     (is (sched/all-scheduled? s jk tk))
-    (is (not (empty? (sched/get-triggers s [tk]))))
-    (is (not (empty? (sched/get-jobs s [jk]))))
+    (is (seq (sched/get-triggers s [tk])))
+    (is (seq (sched/get-jobs s [jk])))
     (let [t (sched/get-trigger s tk)
           m (from-trigger t)]
       (is t)
@@ -85,10 +88,10 @@
     (is (sched/get-job s jk))
     (is (nil? (sched/get-job s (j/key "ab88fsyd7f" "k28s8d77s"))))
     (is (nil? (sched/get-trigger s (t/key "ab88fsyd7f"))))
-    (is (not (empty? (sched/get-trigger-keys s (m/group-equals "tests")))))
-    (is (not (empty? (sched/get-matching-triggers s (m/group-equals "tests")))))
-    (is (not (empty? (sched/get-job-keys s (m/group-equals "tests")))))
-    (is (not (empty? (sched/get-matching-jobs s (m/group-equals "tests")))))
+    (is (seq (sched/get-trigger-keys s (m/group-equals "tests"))))
+    (is (seq (sched/get-matching-triggers s (m/group-equals "tests"))))
+    (is (seq (sched/get-job-keys s (m/group-equals "tests"))))
+    (is (seq (sched/get-matching-jobs s (m/group-equals "tests"))))
     (Thread/sleep 2000)
     (sched/delete-trigger s tk)
     (is (not (sched/all-scheduled? s tk jk)))
@@ -105,13 +108,12 @@
 (def counter3 (atom 0))
 
 (j/defjob JobC
-  [ctx]
+  [_ctx]
   (swap! counter3 inc))
 
 (deftest test-manual-triggering-of-a-job-defined-using-defjob
   (let [s       (-> (sched/initialize) sched/start)
         jk      (j/key "clojurewerkz.quartzite.test.execution-test.job3" "tests")
-        tk      (t/key "clojurewerkz.quartzite.test.execution-test.trigger3" "tests")
         job     (j/build
                  (j/of-type JobC)
                  (j/with-identity "clojurewerkz.quartzite.test.execution-test.job3" "tests"))
@@ -142,7 +144,6 @@
 (deftest test-job-data-access
   (let [s       (-> (sched/initialize) sched/start)
         jk      (j/key "clojurewerkz.quartzite.test.execution-test.job4" "tests")
-        tk      (t/key "clojurewerkz.quartzite.test.execution-test.trigger4" "tests")
         job     (j/build
                  (j/of-type JobD)
                  (j/with-identity "clojurewerkz.quartzite.test.execution-test.job4" "tests")
@@ -216,7 +217,7 @@
 (def latch6 (CountDownLatch. 3))
 
 (j/defjob JobF
-  [ctx]
+  [_ctx]
   (.countDown ^CountDownLatch latch6))
 
 (deftest test-basic-periodic-execution-with-calendar-interval-schedule
@@ -243,7 +244,7 @@
 (def counter7 (atom 0))
 
 (j/defjob JobG
-  [ctx]
+  [_ctx]
   (swap! counter7 inc))
 
 (deftest test-double-scheduling
@@ -252,13 +253,13 @@
                  (j/of-type JobG)
                  (j/with-identity "clojurewerkz.quartzite.test.execution-test.job7" "tests"))
         trigger  (t/build
-                  (t/start-at (-> 2 seconds from-now))
+                  (t/start-at (Date/from (.plus (Instant/now) 2 ChronoUnit/SECONDS)))
                   (t/with-schedule (calin/schedule
                                     (calin/with-interval-in-seconds 2))))]
     (is (sched/schedule s job trigger))
     ;; schedule will raise an exception
     (is (thrown?
-         org.quartz.ObjectAlreadyExistsException
+         ObjectAlreadyExistsException
          (sched/schedule s job trigger)))
     ;; but maybe-schedule will not
     (is (not (sched/maybe-schedule s job trigger)))

--- a/test/clojurewerkz/quartzite/test/jobs_test.clj
+++ b/test/clojurewerkz/quartzite/test/jobs_test.clj
@@ -1,9 +1,9 @@
 (ns clojurewerkz.quartzite.test.jobs-test
   (:refer-clojure :exclude [key])
-  (:require [clojure.test :refer :all]
-            [clojurewerkz.quartzite.jobs :refer :all]
-            [clojurewerkz.quartzite.conversion :refer :all])
-  (:import [org.quartz JobDataMap]))
+  (:require [clojure.test :refer [deftest is]]
+            [clojurewerkz.quartzite.jobs :as jobs]
+            [clojurewerkz.quartzite.conversion :refer [from-job-data to-job-data]])
+  (:import (org.quartz Job JobDataMap)))
 
 
 ;;
@@ -11,12 +11,12 @@
 ;;
 
 (deftest test-instantiation-of-keys
-  (is (not (= (key) (key))))
-  (is (not (= (key "key1") (key))))
-  (is (not (= (key "key1") (key "key2"))))
-  (is (not (= (key "key1" "group1") (key "key1" "group2"))))
-  (is (= (key "key1" "group1") (key "key1" "group1")))
-  (is (= (key "key1") (key "key1"))))
+  (is (not (= (jobs/key) (jobs/key))))
+  (is (not (= (jobs/key "key1") (jobs/key))))
+  (is (not (= (jobs/key "key1") (jobs/key "key2"))))
+  (is (not (= (jobs/key "key1" "group1") (jobs/key "key1" "group2"))))
+  (is (= (jobs/key "key1" "group1") (jobs/key "key1" "group1")))
+  (is (= (jobs/key "key1") (jobs/key "key1"))))
 
 
 
@@ -25,51 +25,51 @@
 ;;
 
 (defrecord AJob []
-  org.quartz.Job
-  (execute [this ctx]
+  Job
+  (execute [_this _ctx]
     ;; intentional no-op
     ))
 
 (deftest test-job-builder-dsl-example1
-  (let [job (build (with-identity    "basic.job1" "basic.group1")
-                   (with-description "A description")
-                   (of-type AJob))]
-    (is (= (key "basic.job1" "basic.group1") (.getKey job)))))
+  (let [job (jobs/build (jobs/with-identity    "basic.job1" "basic.group1")
+                        (jobs/with-description "A description")
+                        (jobs/of-type AJob))]
+    (is (= (jobs/key "basic.job1" "basic.group1") (.getKey job)))))
 
 
 (deftest test-job-builder-dsl-example2
-  (let [job (build (with-identity    "basic.job2" "basic.group2")
-                   (with-description "A description")
-                   (of-type AJob))]
+  (let [job (jobs/build (jobs/with-identity    "basic.job2" "basic.group2")
+                        (jobs/with-description "A description")
+                        (jobs/of-type AJob))]
     (is (= "A description" (.getDescription job)))))
 
 
 (deftest test-job-builder-dsl-example3
-  (let [job (build (with-identity    "basic.job3" "basic.group3")
-                   (with-description "A description")
-                   (of-type AJob))]
+  (let [job (jobs/build (jobs/with-identity    "basic.job3" "basic.group3")
+                        (jobs/with-description "A description")
+                        (jobs/of-type AJob))]
     (.getJobClass job)))
 
 (deftest test-job-builder-dsl-example4
-  (let [job (build (with-identity    "basic.job4" "basic.group4")
-                   (store-durably)
-                   (request-recovery)
-                   (of-type AJob))]
+  (let [job (jobs/build (jobs/with-identity    "basic.job4" "basic.group4")
+                        (jobs/store-durably)
+                        (jobs/request-recovery)
+                        (jobs/of-type AJob))]
     (is (.requestsRecovery job))
     (is (.isDurable job))))
 
 (deftest test-job-builder-dsl-example5
-  (let [jk  (key "basic.job5" "basic.group5")
-        job (build (with-identity jk)
-                   (of-type AJob)
-                   (store-durably))]
+  (let [jk  (jobs/key "basic.job5" "basic.group5")
+        job (jobs/build (jobs/with-identity jk)
+                        (jobs/of-type AJob)
+                        (jobs/store-durably))]
     (is (= jk (.getKey job)))))
 
 (deftest test-job-builder-dsl-example6
-  (let [jk  (key "basic.job6")
-        job (build (with-identity jk)
-                   (of-type AJob)
-                   (store-durably))]
+  (let [jk  (jobs/key "basic.job6")
+        job (jobs/build (jobs/with-identity jk)
+                        (jobs/of-type AJob)
+                        (jobs/store-durably))]
     (is (= jk (.getKey job)))))
 
 

--- a/test/clojurewerkz/quartzite/test/matchers_test.clj
+++ b/test/clojurewerkz/quartzite/test/matchers_test.clj
@@ -1,36 +1,35 @@
 (ns clojurewerkz.quartzite.test.matchers-test
   (:require [clojurewerkz.quartzite.jobs :as j]
-            [clojurewerkz.quartzite.triggers :as t]
-            [clojure.test :refer :all]
-            [clojurewerkz.quartzite.matchers :refer :all]))
+            [clojure.test :refer [deftest is testing are]]
+            [clojurewerkz.quartzite.matchers :as matchers]))
 
 
 (deftest test-group-matcher-factory-functions
   (testing "group-equals"
-    (let [g (group-equals "abc")]
+    (let [g (matchers/group-equals "abc")]
       (is (.isMatch g (j/key "job1" "abc")))
       (is (not (.isMatch g (j/key "job1" "group2"))))
       (is (not (.isMatch g (j/key "job1"))))
       (is (.isMatch g (j/key "job99" "abc")))))
   (testing "group-starts-with"
-    (let [g (group-starts-with "abc")]
+    (let [g (matchers/group-starts-with "abc")]
       (is (.isMatch g (j/key "job1" "abcdef")))
       (is (.isMatch g (j/key "job99" "abcdef")))
       (is (not (.isMatch g (j/key "job1" "group2"))))
       (is (not (.isMatch g (j/key "job1"))))))
   (testing "group-ends-with"
-    (let [g (group-ends-with "def")]
+    (let [g (matchers/group-ends-with "def")]
       (is (.isMatch g (j/key "job1" "abcdef")))
       (is (.isMatch g (j/key "job99" "abcdef")))
       (is (not (.isMatch g (j/key "job1" "group2"))))
       (is (not (.isMatch g (j/key "job1"))))))
   (testing "group-contains"
-    (let [g (group-contains "bc")]
-      (are [key] (is (match? g key))
+    (let [g (matchers/group-contains "bc")]
+      (are [key] (is (matchers/match? g key))
         (j/key "job1" "abcdef")
         (j/key "job1" "bcolumbia")
         (j/key "job1" "abc"))
-      (are [key] (is (not (match? g key)))
+      (are [key] (is (not (matchers/match? g key)))
         (j/key "job1" "def")
         (j/key "job888")
         (j/key "job1" "generation.invoices")))))

--- a/test/clojurewerkz/quartzite/test/querying_test.clj
+++ b/test/clojurewerkz/quartzite/test/querying_test.clj
@@ -4,17 +4,17 @@
             [clojurewerkz.quartzite.matchers  :as matchers]
             [clojurewerkz.quartzite.triggers  :as t]
             [clojurewerkz.quartzite.schedule.calendar-interval :as calin]
-            [clojure.test :refer :all]))
+            [clojure.test :refer [deftest is]]))
 
 ;;
 ;; Group Names operations
 ;;
 
 (j/defjob NoOpJob
-  [ctx])
+  [_ctx])
 
 (j/defjob LongRunningJob
-  [ctx]
+  [_ctx]
   (Thread/sleep 5000))
 
 (defn make-no-op-job
@@ -83,7 +83,7 @@
     (let [jk (j/key job-id job-group)
           triggers (sched/get-triggers-of-job s jk)]
       (is (= 1 (count triggers)))
-      (is (.equals (first triggers) tk1)))
+      (is (= (first triggers) tk1)))
     (sched/shutdown s)))
 
 (deftest test-get-executing-jobs

--- a/test/clojurewerkz/quartzite/test/schedule/calendar_interval_test.clj
+++ b/test/clojurewerkz/quartzite/test/schedule/calendar_interval_test.clj
@@ -1,84 +1,79 @@
 (ns clojurewerkz.quartzite.test.schedule.calendar-interval-test
-  (:refer-clojure :exclude [key])
-  (:require [clojure.test :refer :all]
-            [clojurewerkz.quartzite.schedule.calendar-interval :refer :all])
-  (:import [org.quartz DateBuilder DateBuilder$IntervalUnit]
-           [org.quartz.impl.triggers CalendarIntervalTriggerImpl]))
+  (:require [clojure.test :refer [deftest is]]
+            [clojurewerkz.quartzite.schedule.calendar-interval :as calendar-interval])
+  (:import (org.quartz DateBuilder$IntervalUnit)
+           (org.quartz.impl.triggers CalendarIntervalTriggerImpl)))
 
 
 (deftest test-calendar-interval-schedule-dsl-example1
   (let [i     2
-        n     10
-        ^CalendarIntervalTriggerImpl sched (schedule
-                                              (with-interval-in-seconds i)
-                                              (with-misfire-handling-instruction-ignore-misfires)
-                                              (finalize))]
+        ^CalendarIntervalTriggerImpl sched (calendar-interval/schedule
+                                              (calendar-interval/with-interval-in-seconds i)
+                                              (calendar-interval/with-misfire-handling-instruction-ignore-misfires)
+                                              (calendar-interval/finalize))]
     (is (= i (.getRepeatInterval sched)))
     (is (= DateBuilder$IntervalUnit/SECOND (.getRepeatIntervalUnit sched)))))
 
 
 (deftest test-calendar-interval-schedule-dsl-example2
   (let [i     5
-        n     10
-        ^CalendarIntervalTriggerImpl sched (schedule
-                                              (with-interval-in-seconds i)
-                                              (ignore-misfires)
-                                              (finalize))]
+        ^CalendarIntervalTriggerImpl sched (calendar-interval/schedule
+                                              (calendar-interval/with-interval-in-seconds i)
+                                              (calendar-interval/ignore-misfires)
+                                              (calendar-interval/finalize))]
     (is (= i (.getRepeatInterval sched)))))
 
 
 (deftest test-calendar-interval-schedule-dsl-example3
   (let [i     3
-        n     10
-        ^CalendarIntervalTriggerImpl sched (schedule
-                                              (with-interval-in-minutes i)
-                                              (with-misfire-handling-instruction-fire-and-proceed)
-                                              (finalize))]
+        ^CalendarIntervalTriggerImpl sched (calendar-interval/schedule
+                                              (calendar-interval/with-interval-in-minutes i)
+                                              (calendar-interval/with-misfire-handling-instruction-fire-and-proceed)
+                                              (calendar-interval/finalize))]
     (is (= i (.getRepeatInterval sched)))
     (is (= DateBuilder$IntervalUnit/MINUTE (.getRepeatIntervalUnit sched)))))
 
 
 (deftest test-calendar-interval-schedule-dsl-example4
   (let [i     333
-        n     10
-        ^CalendarIntervalTriggerImpl sched (schedule
-                                              (with-interval-in-hours i)
-                                              (finalize))]
+        ^CalendarIntervalTriggerImpl sched (calendar-interval/schedule
+                                              (calendar-interval/with-interval-in-hours i)
+                                              (calendar-interval/finalize))]
     (is (= i (.getRepeatInterval sched)))
     (is (= DateBuilder$IntervalUnit/HOUR (.getRepeatIntervalUnit sched)))))
 
 
 (deftest test-calendar-interval-schedule-dsl-example5
   (let [i       4
-        ^CalendarIntervalTriggerImpl sched (schedule
-                                              (with-interval-in-days i)
-                                              (with-misfire-handling-instruction-do-nothing)
-                                              (finalize))]
+        ^CalendarIntervalTriggerImpl sched (calendar-interval/schedule
+                                              (calendar-interval/with-interval-in-days i)
+                                              (calendar-interval/with-misfire-handling-instruction-do-nothing)
+                                              (calendar-interval/finalize))]
     (is (= i (.getRepeatInterval sched)))
     (is (= DateBuilder$IntervalUnit/DAY (.getRepeatIntervalUnit sched)))))
 
 
 (deftest test-calendar-interval-schedule-dsl-example6
   (let [i       3
-        ^CalendarIntervalTriggerImpl sched (schedule
-                                              (with-interval-in-weeks i)
-                                              (finalize))]
+        ^CalendarIntervalTriggerImpl sched (calendar-interval/schedule
+                                              (calendar-interval/with-interval-in-weeks i)
+                                              (calendar-interval/finalize))]
     (is (= i (.getRepeatInterval sched)))
     (is (= DateBuilder$IntervalUnit/WEEK (.getRepeatIntervalUnit sched)))))
 
 
 (deftest test-calendar-interval-schedule-dsl-example7
   (let [i       3
-        ^CalendarIntervalTriggerImpl sched (schedule
-                                              (with-interval-in-months i)
-                                              (finalize))]
+        ^CalendarIntervalTriggerImpl sched (calendar-interval/schedule
+                                              (calendar-interval/with-interval-in-months i)
+                                              (calendar-interval/finalize))]
     (is (= i (.getRepeatInterval sched)))
     (is (= DateBuilder$IntervalUnit/MONTH (.getRepeatIntervalUnit sched)))))
 
 (deftest test-calendar-interval-schedule-dsl-example8
   (let [i       3
-        ^CalendarIntervalTriggerImpl sched (schedule
-                                              (with-interval-in-years i)
-                                              (finalize))]
+        ^CalendarIntervalTriggerImpl sched (calendar-interval/schedule
+                                              (calendar-interval/with-interval-in-years i)
+                                              (calendar-interval/finalize))]
     (is (= i (.getRepeatInterval sched)))
     (is (= DateBuilder$IntervalUnit/YEAR (.getRepeatIntervalUnit sched)))))

--- a/test/clojurewerkz/quartzite/test/schedule/cron_test.clj
+++ b/test/clojurewerkz/quartzite/test/schedule/cron_test.clj
@@ -1,100 +1,115 @@
 (ns clojurewerkz.quartzite.test.schedule.cron-test
-  (:refer-clojure :exclude [key])
-  (:require [clojure.test :refer :all]
-            [clojurewerkz.quartzite.schedule.cron :refer :all]
-            [clj-time.core :refer [date-time]])
-  (:import [org.quartz CronScheduleBuilder DateBuilder]
-           [org.quartz.impl.triggers CronTriggerImpl]
-           [org.joda.time DateTime]
-           [java.util TimeZone]))
+  (:require [clojure.test :refer [deftest is]]
+            [clojurewerkz.quartzite.schedule.cron :as cron])
+  (:import (java.time OffsetDateTime ZoneOffset)
+           (org.quartz DateBuilder)
+           (org.quartz.impl.triggers CronTriggerImpl)
+           (java.util Calendar TimeZone)))
 
+(defn date-time
+  ([year month day hour]
+   (date-time year month day hour ZoneOffset/UTC))
+  ([year month day hour ^ZoneOffset zone-offset]
+   (OffsetDateTime/of (int year) (int month) (int day) (int hour) (int 0) (int 0) (int 0) zone-offset)))
+
+(defn offset-date-time-to-calendar [^OffsetDateTime odt]
+  (doto (Calendar/getInstance (TimeZone/getTimeZone "UTC"))
+    (.setTimeInMillis (.toEpochMilli (.toInstant odt)))))
 
 (deftest test-cron-schedule-dsl-example1
   (let [s     "0 0 12 15 * ?"
-        ^DateTime d1     (date-time 2025 2 15 12)
-        ^DateTime d2     (date-time 2025 2 16 12)
+        d1     (date-time 2035 2 15 12)
+        d2     (date-time 2035 2 16 12)
         ^TimeZone tz     (TimeZone/getTimeZone "Europe/Moscow")
-        ^CronTriggerImpl sched  (schedule
-                                  (cron-schedule s)
-                                  (in-time-zone tz)
-                                  (with-misfire-handling-instruction-ignore-misfires)
-                                  (finalize))]
+        ^CronTriggerImpl sched  (cron/schedule
+                                  (cron/cron-schedule s)
+                                  (cron/in-time-zone tz)
+                                  (cron/with-misfire-handling-instruction-ignore-misfires)
+                                  (cron/finalize))]
     (is (= s (.getCronExpression sched)))
-    (is (.willFireOn sched (.toCalendar d1 nil) true))
-    (is (not (.willFireOn sched (.toCalendar d2 nil) true)))))
+    (is (.willFireOn sched (offset-date-time-to-calendar d1) true))
+    (is (not (.willFireOn sched (offset-date-time-to-calendar d2) true)))))
 
 
 (deftest test-cron-schedule-dsl-example2
-  (let [^DateTime d1     (date-time 2025 2 15 15)
-        ^DateTime d2     (date-time 2025 2 16 15)
-        ^CronTriggerImpl sched (schedule
-                                 (daily-at-hour-and-minute 15 0)
-                                 (ignore-misfires)
-                                 (finalize))]
+  (let [d1     (date-time 2035 2 15 15)
+        d2     (date-time 2035 2 16 15)
+        ^CronTriggerImpl sched (cron/schedule
+                                 (cron/daily-at-hour-and-minute 15 0)
+                                 (cron/in-time-zone (TimeZone/getTimeZone "UTC"))
+                                 (cron/ignore-misfires)
+                                 (cron/finalize))]
     (is (= "0 0 15 ? * *" (.getCronExpression sched)))
-    (is (.willFireOn sched (.toCalendar d1 nil) true))
-    (is (.willFireOn sched (.toCalendar d2 nil) true))))
+    (is (.willFireOn sched (offset-date-time-to-calendar d1) true))
+    (is (.willFireOn sched (offset-date-time-to-calendar d2) true))))
 
 
 (deftest test-cron-schedule-dsl-example3
-  (let [^DateTime d1     (date-time 2025 1  1  15)
-        ^DateTime d2     (date-time 2025 1  2  15)
-        ^DateTime d3     (date-time 2025 1  8  15)
-        ^CronTriggerImpl sched (schedule
-                                 (weekly-on-day-and-hour-and-minute DateBuilder/WEDNESDAY 15 0)
-                                 (with-misfire-handling-instruction-do-nothing)
-                                 (finalize))]
+  (let [d1     (date-time 2035 1  3  15)
+        d2     (date-time 2035 1  2  15)
+        d3     (date-time 2035 1  10 15)
+        ^CronTriggerImpl sched (cron/schedule
+                                 (cron/weekly-on-day-and-hour-and-minute DateBuilder/WEDNESDAY 15 0)
+                                 (cron/in-time-zone (TimeZone/getTimeZone "UTC"))
+                                 (cron/with-misfire-handling-instruction-do-nothing)
+                                 (cron/finalize))]
     (is (= "0 0 15 ? * 4" (.getCronExpression sched)))
-    (is (.willFireOn sched (.toCalendar d1 nil) true))
-    (is (not (.willFireOn sched (.toCalendar d2 nil) true)))
-    (is (.willFireOn sched (.toCalendar d3 nil) true))))
+    (is (.willFireOn sched (offset-date-time-to-calendar d1) true))
+    (is (not (.willFireOn sched (offset-date-time-to-calendar d2) true)))
+    (is (.willFireOn sched (offset-date-time-to-calendar d3) true))))
 
 
 (deftest test-cron-schedule-dsl-example4
-  (let [^DateTime d1     (date-time 2025 1  7  15)
-        ^DateTime d2     (date-time 2025 1  3  15)
-        ^CronTriggerImpl sched (schedule
-                                 (monthly-on-day-and-hour-and-minute 7 15 0)
-                                 (with-misfire-handling-instruction-fire-and-proceed)
-                                 (finalize))]
+  (let [d1     (date-time 2035 1  7  15)
+        d2     (date-time 2035 1  3  15)
+        ^CronTriggerImpl sched (cron/schedule
+                                 (cron/monthly-on-day-and-hour-and-minute 7 15 0)
+                                 (cron/in-time-zone (TimeZone/getTimeZone "UTC"))
+                                 (cron/with-misfire-handling-instruction-fire-and-proceed)
+                                 (cron/finalize))]
     (is (= "0 0 15 7 * ?" (.getCronExpression sched)))
-    (is (.willFireOn sched (.toCalendar d1 nil) true))
-    (is (not (.willFireOn sched (.toCalendar d2 nil) true)))))
+    (is (.willFireOn sched (offset-date-time-to-calendar d1) true))
+    (is (not (.willFireOn sched (offset-date-time-to-calendar d2) true)))))
+
+
 
 (deftest test-cron-schedule-last-day-of-the-month
-  (let [^DateTime d1     (date-time 2025 1  7  15)
-        ^DateTime d2     (date-time 2025 1  31  15)
-        ^DateTime d3     (date-time 2025 2  28  15)
-        ^DateTime d4     (date-time 2025 3  31  15)
-        ^DateTime d5     (date-time 2025 4  30  15)
-        ^DateTime d6     (date-time 2025 4  28  15)
-        ^DateTime d7     (date-time 2024 2  29  15)
-        ^DateTime d8     (date-time 2029 2  28  15)
-        ^CronTriggerImpl sched (schedule
-                                (cron-schedule "0 0 15 L * ?")
-                                 (finalize))]
-    (is (not (.willFireOn sched (.toCalendar d1 nil) true)))
-    (is (.willFireOn sched (.toCalendar d2 nil) true))
-    (is (.willFireOn sched (.toCalendar d3 nil) true))
-    (is (.willFireOn sched (.toCalendar d4 nil) true))
-    (is (.willFireOn sched (.toCalendar d5 nil) true))
-    (is (not (.willFireOn sched (.toCalendar d6 nil) true)))
-    (is (.willFireOn sched (.toCalendar d7 nil) true))
-    (is (.willFireOn sched (.toCalendar d8 nil) true))))
+  (let [
+        d1     (date-time 2035 1  7   0)
+        d2     (date-time 2035 1  31  0)
+        d3     (date-time 2035 2  28  0)
+        d4     (date-time 2035 3  31  0)
+        d5     (date-time 2035 4  30  0)
+        d6     (date-time 2035 4  28  0)
+        d7     (date-time 2036 2  29  0)
+        d8     (date-time 2037 2  28  0)
+        ^CronTriggerImpl sched (cron/schedule
+                                (cron/cron-schedule "0 0 0 L * ?")
+                                (cron/in-time-zone (TimeZone/getTimeZone "UTC"))
+                                (cron/finalize))]
+    (is (not (.willFireOn sched (offset-date-time-to-calendar d1) true)))
+    (is (.willFireOn sched (offset-date-time-to-calendar d2) true))
+    (is (.willFireOn sched (offset-date-time-to-calendar d3) true))
+    (is (.willFireOn sched (offset-date-time-to-calendar d4) true))
+    (is (.willFireOn sched (offset-date-time-to-calendar d5) true))
+    (is (not (.willFireOn sched (offset-date-time-to-calendar d6) true)))
+    (is (.willFireOn sched (offset-date-time-to-calendar d7) true))
+    (is (.willFireOn sched (offset-date-time-to-calendar d8) true))))
 
 (deftest test-cron-schedule-next-to-last-day-of-the-month
-  (let [^DateTime d1     (date-time 2025 1  7  15)
-        ^DateTime d2     (date-time 2025 1  30  15)
-        ^DateTime d3     (date-time 2025 2  27  15)
-        ^DateTime d4     (date-time 2025 3  30  15)
-        ^DateTime d5     (date-time 2025 4  29  15)
-        ^DateTime d6     (date-time 2025 5  31  15)
-        ^CronTriggerImpl sched (schedule
-                                (cron-schedule "0 0 15 L-1 * ?")
-                                 (finalize))]
-    (is (not (.willFireOn sched (.toCalendar d1 nil) true)))
-    (is (.willFireOn sched (.toCalendar d2 nil) true))
-    (is (.willFireOn sched (.toCalendar d3 nil) true))
-    (is (.willFireOn sched (.toCalendar d4 nil) true))
-    (is (.willFireOn sched (.toCalendar d5 nil) true))
-    (is (not (.willFireOn sched (.toCalendar d6 nil) true)))))
+  (let [d1     (date-time 2035 1  7  15)
+        d2     (date-time 2035 1  30  15)
+        d3     (date-time 2035 2  27  15)
+        d4     (date-time 2035 3  30  15)
+        d5     (date-time 2035 4  29  15)
+        d6     (date-time 2035 5  31  15)
+        ^CronTriggerImpl sched (cron/schedule
+                                (cron/cron-schedule "0 0 15 L-1 * ?")
+                                (cron/in-time-zone (TimeZone/getTimeZone "UTC"))
+                                (cron/finalize))]
+    (is (not (.willFireOn sched (offset-date-time-to-calendar d1) true)))
+    (is (.willFireOn sched (offset-date-time-to-calendar d2) true))
+    (is (.willFireOn sched (offset-date-time-to-calendar d3) true))
+    (is (.willFireOn sched (offset-date-time-to-calendar d4) true))
+    (is (.willFireOn sched (offset-date-time-to-calendar d5) true))
+    (is (not (.willFireOn sched (offset-date-time-to-calendar d6) true)))))

--- a/test/clojurewerkz/quartzite/test/schedule/daily_interval_test.clj
+++ b/test/clojurewerkz/quartzite/test/schedule/daily_interval_test.clj
@@ -1,21 +1,19 @@
 (ns clojurewerkz.quartzite.test.schedule.daily-interval-test
-  (:refer-clojure :exclude [key])
-  (:require [clojure.test :refer :all]
-            [clojurewerkz.quartzite.schedule.daily-interval :refer :all])
-  (:import [org.quartz DateBuilder DateBuilder$IntervalUnit SimpleTrigger]
-           [org.quartz.impl.triggers DailyTimeIntervalTriggerImpl]
-           [java.util TreeSet]))
+  (:require [clojure.test :refer [deftest is]]
+            [clojurewerkz.quartzite.schedule.daily-interval :as sdi])
+  (:import (org.quartz DateBuilder$IntervalUnit SimpleTrigger)
+           (org.quartz.impl.triggers DailyTimeIntervalTriggerImpl)))
 
 
 (deftest test-daily-interval-schedule-dsl-example1
   (let [i     2
         n     10
-        ^DailyTimeIntervalTriggerImpl sched (schedule
-                (with-interval-in-seconds i)
-                (with-repeat-count        n)
-                (on-days-of-the-week (TreeSet. [(Integer/valueOf 1) (Integer/valueOf 2) (Integer/valueOf 3) (Integer/valueOf 4)]))
-                (with-misfire-handling-instruction-ignore-misfires)
-                (finalize))]
+        ^DailyTimeIntervalTriggerImpl sched (sdi/schedule
+                (sdi/with-interval-in-seconds i)
+                (sdi/with-repeat-count        n)
+                (sdi/on-days-of-the-week (set [(Integer/valueOf 1) (Integer/valueOf 2) (Integer/valueOf 3) (Integer/valueOf 4)]))
+                (sdi/with-misfire-handling-instruction-ignore-misfires)
+                (sdi/finalize))]
     (is (= i (.getRepeatInterval sched)))
     (is (= DateBuilder$IntervalUnit/SECOND (.getRepeatIntervalUnit sched)))
     (is (= n          (.getRepeatCount    sched)))))
@@ -24,14 +22,14 @@
 (deftest test-daily-interval-schedule-dsl-example2
   (let [i     5
         n     10
-        ^DailyTimeIntervalTriggerImpl sched (schedule
-                (with-interval-in-seconds i)
-                (with-repeat-count        n)
-                (monday-through-friday)
-                (starting-daily-at (time-of-day 15 00 00))
-                (ending-daily-at (time-of-day 15 00 00))
-                (ignore-misfires)
-                (finalize))]
+        ^DailyTimeIntervalTriggerImpl sched (sdi/schedule
+                (sdi/with-interval-in-seconds i)
+                (sdi/with-repeat-count        n)
+                (sdi/monday-through-friday)
+                (sdi/starting-daily-at (sdi/time-of-day 15 00 00))
+                (sdi/ending-daily-at (sdi/time-of-day 15 00 00))
+                (sdi/ignore-misfires)
+                (sdi/finalize))]
     (is (= i (.getRepeatInterval sched)))
     (is (= DateBuilder$IntervalUnit/SECOND (.getRepeatIntervalUnit sched)))
     (is (= n (.getRepeatCount    sched)))))
@@ -40,12 +38,12 @@
 (deftest test-daily-interval-schedule-dsl-example3
   (let [i     3
         n     10
-        ^DailyTimeIntervalTriggerImpl sched (schedule
-                (with-interval-in-minutes i)
-                (with-repeat-count        n)
-                (saturday-and-sunday)
-                (with-misfire-handling-instruction-fire-and-proceed)
-                (finalize))]
+        ^DailyTimeIntervalTriggerImpl sched (sdi/schedule
+                (sdi/with-interval-in-minutes i)
+                (sdi/with-repeat-count        n)
+                (sdi/saturday-and-sunday)
+                (sdi/with-misfire-handling-instruction-fire-and-proceed)
+                (sdi/finalize))]
     (is (= i (.getRepeatInterval sched)))
     (is (= DateBuilder$IntervalUnit/MINUTE (.getRepeatIntervalUnit sched)))
     (is (= n (.getRepeatCount    sched)))))
@@ -54,11 +52,11 @@
 (deftest test-daily-interval-schedule-dsl-example4
   (let [i     333
         n     10
-        ^DailyTimeIntervalTriggerImpl sched (schedule
-                (with-interval-in-hours i)
-                (with-repeat-count      n)
-                (every-day)
-                (finalize))]
+        ^DailyTimeIntervalTriggerImpl sched (sdi/schedule
+                (sdi/with-interval-in-hours i)
+                (sdi/with-repeat-count      n)
+                (sdi/every-day)
+                (sdi/finalize))]
     (is (= i (.getRepeatInterval sched)))
     (is (= DateBuilder$IntervalUnit/HOUR (.getRepeatIntervalUnit sched)))
     (is (= n (.getRepeatCount    sched)))))
@@ -66,18 +64,18 @@
 
 (deftest test-daily-interval-schedule-dsl-example5
   (let [i       4
-        ^DailyTimeIntervalTriggerImpl sched (schedule
-                (with-interval-in-hours i)
-                (on-saturday-and-sunday)
-                (finalize))]
+        ^DailyTimeIntervalTriggerImpl sched (sdi/schedule
+                (sdi/with-interval-in-hours i)
+                (sdi/on-saturday-and-sunday)
+                (sdi/finalize))]
     (is (= i (.getRepeatInterval sched)))
     (is (= (SimpleTrigger/REPEAT_INDEFINITELY) (.getRepeatCount sched)))))
 
 
 (deftest test-daily-interval-schedule-dsl-example6
   (let [i       3
-        ^DailyTimeIntervalTriggerImpl sched (schedule
-                (with-interval-in-days i)
-                (on-monday-through-friday)
-                (finalize))]
+        ^DailyTimeIntervalTriggerImpl sched (sdi/schedule
+                (sdi/with-interval-in-days i)
+                (sdi/on-monday-through-friday)
+                (sdi/finalize))]
     (is (= (* 24 i) (.getRepeatInterval sched)))))

--- a/test/clojurewerkz/quartzite/test/schedule/simple_test.clj
+++ b/test/clojurewerkz/quartzite/test/schedule/simple_test.clj
@@ -1,19 +1,18 @@
 (ns clojurewerkz.quartzite.test.schedule.simple-test
-  (:refer-clojure :exclude [key])
-  (:require [clojure.test :refer :all]
-            [clojurewerkz.quartzite.schedule.simple :refer :all])
-  (:import [org.quartz DateBuilder SimpleTrigger Trigger]
-           [org.quartz.impl.triggers SimpleTriggerImpl]))
+  (:require [clojure.test :refer [deftest is]]
+            [clojurewerkz.quartzite.schedule.simple :as simple])
+  (:import (org.quartz DateBuilder SimpleTrigger)
+           (org.quartz.impl.triggers SimpleTriggerImpl)))
 
 
 (deftest test-simple-schedule-dsl-example1
   (let [i     2
         n     10
-        ^SimpleTriggerImpl sched (schedule
-                                   (with-interval-in-seconds i)
-                                   (with-repeat-count        n)
-                                   (with-misfire-handling-instruction-ignore-misfires)
-                                   (finalize))]
+        ^SimpleTriggerImpl sched (simple/schedule
+                                   (simple/with-interval-in-seconds i)
+                                   (simple/with-repeat-count        n)
+                                   (simple/with-misfire-handling-instruction-ignore-misfires)
+                                   (simple/finalize))]
     (is (= (* 1000 i) (.getRepeatInterval sched)))
     (is (= n          (.getRepeatCount    sched)))))
 
@@ -21,11 +20,11 @@
 (deftest test-simple-schedule-dsl-example2
   (let [i     5
         n     10
-        ^SimpleTriggerImpl sched (schedule
-                                   (with-interval-in-milliseconds i)
-                                   (with-repeat-count        n)
-                                   (ignore-misfires)
-                                   (finalize))]
+        ^SimpleTriggerImpl sched (simple/schedule
+                                   (simple/with-interval-in-milliseconds i)
+                                   (simple/with-repeat-count        n)
+                                   (simple/ignore-misfires)
+                                   (simple/finalize))]
     (is (= i (.getRepeatInterval sched)))
     (is (= n (.getRepeatCount    sched)))))
 
@@ -33,11 +32,11 @@
 (deftest test-simple-schedule-dsl-example3
   (let [i     3
         n     10
-        ^SimpleTriggerImpl sched (schedule
-                                   (with-interval-in-minutes i)
-                                   (with-repeat-count        n)
-                                   (next-with-remaining-count)
-                                   (finalize))]
+        ^SimpleTriggerImpl sched (simple/schedule
+                                   (simple/with-interval-in-minutes i)
+                                   (simple/with-repeat-count        n)
+                                   (simple/next-with-remaining-count)
+                                   (simple/finalize))]
     (is (= (* i (DateBuilder/MILLISECONDS_IN_MINUTE)) (.getRepeatInterval sched)))
     (is (= n (.getRepeatCount    sched)))))
 
@@ -45,31 +44,31 @@
 (deftest test-simple-schedule-dsl-example4
   (let [i     333
         n     10
-        ^SimpleTriggerImpl sched (schedule
-                                   (with-interval-in-hours i)
-                                   (with-repeat-count      n)
-                                   (now-with-remaining-count)
-                                   (finalize))]
+        ^SimpleTriggerImpl sched (simple/schedule
+                                   (simple/with-interval-in-hours i)
+                                   (simple/with-repeat-count      n)
+                                   (simple/now-with-remaining-count)
+                                   (simple/finalize))]
     (is (= (* i (DateBuilder/MILLISECONDS_IN_HOUR)) (.getRepeatInterval sched)))
     (is (= n (.getRepeatCount    sched)))))
 
 
 (deftest test-simple-schedule-dsl-example5
   (let [i       4
-        ^SimpleTriggerImpl sched (schedule
-                                   (with-interval-in-hours i)
-                                   (repeat-forever)
-                                   (now-with-existing-count)
-                                   (finalize))]
+        ^SimpleTriggerImpl sched (simple/schedule
+                                   (simple/with-interval-in-hours i)
+                                   (simple/repeat-forever)
+                                   (simple/now-with-existing-count)
+                                   (simple/finalize))]
     (is (= (* i (DateBuilder/MILLISECONDS_IN_HOUR)) (.getRepeatInterval sched)))
     (is (= (SimpleTrigger/REPEAT_INDEFINITELY) (.getRepeatCount sched)))))
 
 
 (deftest test-simple-schedule-dsl-example6
   (let [i       3
-        ^SimpleTriggerImpl sched (schedule
-                                   (with-interval-in-days i)
-                                   (next-with-existing-count)
-                                   (repeat-forever)
-                                   (finalize))]
+        ^SimpleTriggerImpl sched (simple/schedule
+                                   (simple/with-interval-in-days i)
+                                   (simple/next-with-existing-count)
+                                   (simple/repeat-forever)
+                                   (simple/finalize))]
     (is (= (* 24 i (DateBuilder/MILLISECONDS_IN_HOUR)) (.getRepeatInterval sched)))))

--- a/test/clojurewerkz/quartzite/test/simple_schedule_test.clj
+++ b/test/clojurewerkz/quartzite/test/simple_schedule_test.clj
@@ -3,14 +3,14 @@
             [clojurewerkz.quartzite.jobs      :as j]
             [clojurewerkz.quartzite.triggers  :as t]
             [clojurewerkz.quartzite.schedule.calendar-interval :as calin]
-            [clojure.test :refer :all]))
+            [clojure.test :refer [deftest is]]))
 
 ;;
 ;; Group Names operations
 ;;
 
 (j/defjob NoOpJob
-  [ctx])
+  [_ctx])
 
 (defn make-durable-no-op-job
   [name job-group]
@@ -38,8 +38,8 @@
 
     (sched/add-job s job1)
 
-    (is (.equals (sched/get-job s jk) job1))
-    (is (.equals job1 (sched/get-job s job-group job-id)))
+    (is (= (sched/get-job s jk) job1))
+    (is (= job1 (sched/get-job s job-group job-id)))
     (is (zero? (count (sched/get-triggers-of-job s jk))))
     (sched/shutdown s)))
 
@@ -63,5 +63,5 @@
 
       (let [triggers (sched/get-triggers-of-job s jk)]
         (is (= 1 (count triggers)))
-        (is (.equals (first triggers) trig1)))
+        (is (= (first triggers) trig1)))
       (sched/shutdown s))))

--- a/test/clojurewerkz/quartzite/test/stateful_test.clj
+++ b/test/clojurewerkz/quartzite/test/stateful_test.clj
@@ -1,19 +1,15 @@
 (ns clojurewerkz.quartzite.test.stateful-test
-  (:refer-clojure :exclude [await])
   (:require [clojurewerkz.quartzite.scheduler :as sched]
             [clojurewerkz.quartzite.jobs      :as j]
             [clojurewerkz.quartzite.triggers  :as t]
             [clojurewerkz.quartzite.matchers  :as m]
             [clojurewerkz.quartzite.stateful  :as stateful]
             [clojurewerkz.quartzite.schedule.simple :as s]
-            [clojurewerkz.quartzite.schedule.calendar-interval :as calin]
-            [clojure.test :refer :all]
-            [clojurewerkz.quartzite.conversion :refer :all]
-            [clj-time.core :refer [now from-now]])
-  (:import [java.util.concurrent CountDownLatch TimeUnit]
-           org.quartz.impl.matchers.GroupMatcher))
+            [clojure.test :refer [deftest is]]
+            [clojurewerkz.quartzite.conversion :refer [from-trigger]])
+  (:import (java.util.concurrent CountDownLatch TimeUnit)))
 
-(defn ^:private await
+(defn ^:private await-latch
   [^CountDownLatch latch]
   (.await latch 3 TimeUnit/SECONDS))
 
@@ -25,7 +21,7 @@
 
 ; job takes longer than interval
 (stateful/def-stateful-job JobA
-  [ctx]
+  [_ctx]
   (Thread/sleep 1000)
   (.countDown ^CountDownLatch latch1))
 
@@ -46,8 +42,8 @@
         start (System/currentTimeMillis)]
     (sched/schedule s job trigger)
     (is (sched/all-scheduled? s jk tk))
-    (is (not (empty? (sched/get-triggers s [tk]))))
-    (is (not (empty? (sched/get-jobs s [jk]))))
+    (is (seq (sched/get-triggers s [tk])))
+    (is (seq (sched/get-jobs s [jk])))
     (let [t (sched/get-trigger s tk)
           m (from-trigger t)]
       (is t)
@@ -56,8 +52,8 @@
       (is (:start-time m))
       (is (:next-fire-time m)))
     (is (sched/get-job s jk))
-    (is (not (empty? (sched/get-job-keys s (m/group-equals "tests")))))
-    (await latch1)
+    (is (seq (sched/get-job-keys s (m/group-equals "tests"))))
+    (await-latch latch1)
     (let [time-to-run (- (System/currentTimeMillis) start)]
       (is (>= time-to-run 2000)))
     (sched/shutdown s)))
@@ -80,8 +76,6 @@
 
 (deftest test-stateful-job-state
   (let [s       (-> (sched/initialize) sched/start)
-        jk      (j/key "clojurewerkz.quartzite.test.execution.job2"     "tests")
-        tk      (t/key "clojurewerkz.quartzite.test.execution.trigger2" "tests")
         job     (j/build
                  (j/of-type JobB)
                  (j/with-identity "clojurewerkz.quartzite.test.execution.job2" "tests"))
@@ -91,9 +85,8 @@
                   (t/with-description "just a trigger")
                   (t/with-schedule (s/schedule
                                     (s/with-repeat-count 10)
-                                    (s/with-interval-in-milliseconds 10))))
-        start (System/currentTimeMillis)]
+                                    (s/with-interval-in-milliseconds 10))))]
     (sched/schedule s job trigger)
-    (is (not (empty? (sched/get-job-keys s (m/group-equals "tests")))))
-    (await latch2)
+    (is (seq (sched/get-job-keys s (m/group-equals "tests"))))
+    (await-latch latch2)
     (is (= @atom1 10))))

--- a/test/clojurewerkz/quartzite/test/triggers_test.clj
+++ b/test/clojurewerkz/quartzite/test/triggers_test.clj
@@ -1,46 +1,46 @@
 (ns clojurewerkz.quartzite.test.triggers-test
   (:refer-clojure :exclude [key])
   (:require [clojurewerkz.quartzite.jobs :as jobs]
-            [clojure.test :refer :all]
-            [clojurewerkz.quartzite.conversion :refer :all]
-            [clojurewerkz.quartzite.triggers :refer :all]
-            [clj-time.core :refer [now minus plus days hours minutes]])
-  (:import [java.util Date]
-           [org.joda.time DateTime]))
+            [clojure.test :refer [deftest is]]
+            [clojurewerkz.quartzite.conversion :refer [from-job-data to-job-data]]
+            [clojurewerkz.quartzite.triggers :as triggers])
+  (:import (java.time Instant)
+           (java.time.temporal ChronoUnit)
+           (java.util Date)))
 
 
 (deftest test-instantiation-of-keys
-  (is (not (= (key) (key))))
-  (is (not (= (key "key1") (key))))
-  (is (not (= (key "key1") (key "key2"))))
-  (is (not (= (key "key1" "group1") (key "key1" "group2"))))
-  (is (= (key "key1" "group1") (key "key1" "group1")))
-  (is (= (key "key1") (key "key1"))))
+  (is (not (= (triggers/key) (triggers/key))))
+  (is (not (= (triggers/key "key1") (triggers/key))))
+  (is (not (= (triggers/key "key1") (triggers/key "key2"))))
+  (is (not (= (triggers/key "key1" "group1") (triggers/key "key1" "group2"))))
+  (is (= (triggers/key "key1" "group1") (triggers/key "key1" "group1")))
+  (is (= (triggers/key "key1") (triggers/key "key1"))))
 
 
 (deftest test-trigger-builder-dsl-example1
-  (let [trigger (build (with-identity    "basic.trigger1" "basic.group1")
-                       (with-description "A description"))]
-    (is (= (key "basic.trigger1" "basic.group1") (.getKey trigger)))
+  (let [trigger (triggers/build (triggers/with-identity    "basic.trigger1" "basic.group1")
+                                (triggers/with-description "A description"))]
+    (is (= (triggers/key "basic.trigger1" "basic.group1") (.getKey trigger)))
     (is (= "A description" (.getDescription trigger)))))
 
 (deftest test-trigger-builder-dsl-example2
-  (let [trigger (build (with-identity    "basic.trigger2")
-                       (with-description "A description")
-                       (with-priority    3))]
+  (let [trigger (triggers/build (triggers/with-identity    "basic.trigger2")
+                                (triggers/with-description "A description")
+                                (triggers/with-priority    3))]
     (is (= 3 (.getPriority trigger)))))
 
 
 (deftest test-trigger-builder-dsl-example3
-  (let [trigger (build (with-identity "basic.trigger3")
-                       (modified-by-calendar "my.holidays.calendar"))]
+  (let [trigger (triggers/build (triggers/with-identity "basic.trigger3")
+                                (triggers/modified-by-calendar "my.holidays.calendar"))]
     (is (= "my.holidays.calendar" (.getCalendarName trigger)))))
 
 
 (deftest test-trigger-builder-dsl-example4
   (let [d       (Date.)
-        trigger (build (with-identity "basic.trigger4")
-                       (start-now))
+        trigger (triggers/build (triggers/with-identity "basic.trigger4")
+                                (triggers/start-now))
         st      (.getStartTime trigger)]
     (is (= (.getYear d)    (.getYear st)))
     (is (= (.getMonth d)   (.getMonth st)))
@@ -50,49 +50,49 @@
 
 
 (deftest test-trigger-builder-dsl-example5
-  (let [start   (.toDate ^DateTime (now))
-        end     (.toDate ^DateTime (plus (now) (hours 3)))
-        trigger (build (with-identity "basic.trigger5")
-                       (start-at start)
-                       (end-at   end))]
+  (let [start   (Date/from (Instant/now))
+        end     (Date/from (.plus (Instant/now) 3 ChronoUnit/HOURS))
+        trigger (triggers/build (triggers/with-identity "basic.trigger5")
+                                (triggers/start-at start)
+                                (triggers/end-at   end))]
     (is (= start (.getStartTime trigger)))
     (is (= end   (.getEndTime trigger)))))
 
 
 (deftest test-trigger-builder-dsl-example6
-  (let [trigger (build (with-identity "basic.trigger6")
-                       (start-now)
-                       (for-job "some.job"))]
+  (let [trigger (triggers/build (triggers/with-identity "basic.trigger6")
+                                (triggers/start-now)
+                                (triggers/for-job "some.job"))]
     (is (= (jobs/key "some.job") (.getJobKey trigger)))))
 
 
 (deftest test-trigger-builder-dsl-example7
-  (let [trigger (build (with-identity "basic.trigger7")
-                       (start-now)
-                       (for-job (jobs/key "some.job")))]
+  (let [trigger (triggers/build (triggers/with-identity "basic.trigger7")
+                                (triggers/start-now)
+                                (triggers/for-job (jobs/key "some.job")))]
     (is (= (jobs/key "some.job") (.getJobKey trigger)))))
 
 
 (deftest test-trigger-builder-dsl-example8
-  (let [trigger (build (with-identity "basic.trigger8")
-                       (start-now)
-                       (for-job "collect.underpants" "business"))]
+  (let [trigger (triggers/build (triggers/with-identity "basic.trigger8")
+                                (triggers/start-now)
+                                (triggers/for-job "collect.underpants" "business"))]
     (is (= (jobs/key "collect.underpants" "business") (.getJobKey trigger)))))
 
 (deftest test-trigger-builder-dsl-example9
-  (let [trigger (build (with-identity "basic.trigger8")
-                       (start-now)
-                       (for-job "collect.underpants" "business")
-                       (using-job-data { :who "Gnomes" :what "Know about business" }))]
+  (let [trigger (triggers/build (triggers/with-identity "basic.trigger8")
+                                (triggers/start-now)
+                                (triggers/for-job "collect.underpants" "business")
+                                (triggers/using-job-data { :who "Gnomes" :what "Know about business" }))]
     (is (= (to-job-data { "who" "Gnomes" "what" "Know about business" }) (.getJobDataMap trigger)))
     (is (= { "who" "Gnomes" "what" "Know about business" } (from-job-data (.getJobDataMap trigger))))))
 
 (deftest test-job-builder-dsl-example10
-  (let [tk  (key "basic.trigger10" "basic.group10")
-        trigger (build (with-identity tk))]
+  (let [tk  (triggers/key "basic.trigger10" "basic.group10")
+        trigger (triggers/build (triggers/with-identity tk))]
     (is (= tk (.getKey trigger)))))
 
 (deftest test-job-builder-dsl-example11
-  (let [tk  (key "basic.trigger11")
-        trigger (build (with-identity tk))]
+  (let [tk  (triggers/key "basic.trigger11")
+        trigger (triggers/build (triggers/with-identity tk))]
     (is (= tk (.getKey trigger)))))


### PR DESCRIPTION
- Adds clj-kondo exports for proper linting w/in projects
- Fixes a bunch of linting issues w/o quartzite as well as addresses reflection issues
- Bumps Clojure/Quartz dep versions
- Builds with jdk21 instead of 8
- Removes clj-time as a direct dependency. It will still dynamically extend the DateConversion protocol if joda time is on the classpath (so no breaking change). Joda time is a massive package and generally is irrelevant now and just adds lots of bloat to jars.
- Extends DateConversion further adding support for things like Instant/OffsetDateTime/ZonedDateTime/LocalDateTime/LocalDate/etc
- Updates .gitignore for cursive projects