### PR TITLE
Upgrade Quartz to 2.5.2, fix java.time DateConversion, extend clj-kon…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ deploy.docs.sh
 target/*
 .nrepl*
 .clj-kondo/.cache
+.clj-kondo/imports
 .idea/
 *.iml
 .lsp/

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,10 +1,40 @@
 ## Changes Between Quartzite 2.2.0 and 2.3.0
 
+### Quartz Upgraded to 2.5.2, Clojure 1.12 Supported
+
+[Quartz](http://quartz-scheduler.org/) goes from `2.3.2` to `2.5.2`. The `2.5.0` upgrade had been
+deferred pending [quartz-scheduler/quartz#1298](https://github.com/quartz-scheduler/quartz/issues/1298),
+since resolved.
+
+### Joda Time Support Removed
+
+Breaking. The `clj-time`/Joda Time dependency is gone and `DateConversion` is no longer extended to
+`org.joda.time` types, even when Joda Time is on the classpath. It now covers `java.util.Date`,
+`java.util.Calendar` and the `java.time` types (`Instant`, `OffsetDateTime`, `ZonedDateTime`,
+`LocalDateTime`, `LocalDate`). To keep passing Joda objects to `triggers/start-at` and friends,
+convert to `java.time` or extend the protocol yourself:
+
+``` clojure
+(extend-protocol clojurewerkz.quartzite.conversion/DateConversion
+  org.joda.time.base.BaseDateTime
+  (to-date [input] (.toDate input)))
+```
+
+### `DateConversion` Fixes
+
+`to-date` threw for `LocalDateTime` and `LocalDate` — `ZoneId/systemDefault` was missing
+parentheses, which Clojure 1.12 compiles to a method *value* rather than a call. It is now also
+tagged `^java.util.Date`, so `triggers/start-at` and `end-at` no longer reflect against the
+`startAt(java.time.Instant)` overload Quartz 2.5 added; implementations are expected to honour that
+and return a `java.util.Date`.
+
+### clj-kondo Support
+
+Quartzite now exports [clj-kondo](https://github.com/clj-kondo/clj-kondo) configuration, with hooks
+for the `jobs/build`, `triggers/build` and `schedule` threading macros so that linting Quartzite DSL
+code no longer reports spurious arity errors. Lint issues in the library itself have been addressed.
+
 GitHub issue: [#46](https://github.com/michaelklishin/quartzite/issues/46)
-Add clj-kondo support and address lint issues
-Remove direct dependency on clj-time/Joda Time (DateConversion protocol is still extended if Joda Time is on the 
-classpath)
-Add support for Quartz 2.4.0 and Clojure 1.12.0
 
 Contributed by @vincentjames501.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Quartzite is a powerful Clojure scheduling library built on top the [Quartz Sche
  * Be (reasonably) idiomatic but easy to understand for people familiar with Quartz
  * Be [well documented](doc/guides/README.md)
  * Be [well tested](https://github.com/michaelklishin/quartzite/tree/master/test/clojurewerkz/quartzite/test)
- * Integrate with libraries like JodaTime where appropriate, like [Monger, a modern Clojure MongoDB client](https://github.com/michaelklishin/monger) does
+ * Integrate with `java.time` where appropriate
  * Not a half-assed effort: libraries should be well maintained and test-driven or not be open sourced in the first place
 
 

--- a/project.clj
+++ b/project.clj
@@ -3,9 +3,7 @@
   :min-lein-version "2.5.1"
   :license {:name "Eclipse Public License"}
   :dependencies [[org.clojure/clojure "1.12.0"]
-                 ;; 2.5.0 Has a bug that should be fixed before
-                 ;; updating https://github.com/quartz-scheduler/quartz/issues/1298
-                 [org.quartz-scheduler/quartz "2.4.0"]]
+                 [org.quartz-scheduler/quartz "2.5.2"]]
   :source-paths ["src/clojure"]
   :java-source-paths ["src/java"]
   :test-selectors {:all     (constantly true)

--- a/resources/clj-kondo.exports/clojurewerkz/quartzite/clj_kondo/clojurewerkz/quartzite.clj
+++ b/resources/clj-kondo.exports/clojurewerkz/quartzite/clj_kondo/clojurewerkz/quartzite.clj
@@ -2,16 +2,16 @@
   (:require [clj-kondo.hooks-api :as api]))
 
 (defn threaded* [builder-sym final-sym {:keys [node]}]
-  (let [body (rest (:children node))]
-    (let [new-node (api/list-node
-                    (list*
-                     (api/token-node '->)
-                     (concat (when builder-sym
-                               [(api/token-node builder-sym)])
-                             body
-                             (when final-sym
-                               [(api/token-node final-sym)]))))]
-      {:node new-node})))
+  (let [body     (rest (:children node))
+        new-node (api/list-node
+                  (list*
+                   (api/token-node '->)
+                   (concat (when builder-sym
+                             [(api/token-node builder-sym)])
+                           body
+                           (when final-sym
+                             [(api/token-node final-sym)]))))]
+    {:node new-node}))
 
 (defn triggers-build [ctx]
   (threaded* '(org.quartz.TriggerBuilder/newTrigger)
@@ -22,3 +22,20 @@
   (threaded* '(org.quartz.JobBuilder/newJob)
              '(clojurewerkz.quartzite.jobs/finalize)
              ctx))
+
+;; The schedule DSLs thread a builder too, but unlike job/trigger builders they
+;; do not finalize for you, so callers pass `finalize` explicitly.
+
+(defn simple-schedule [ctx]
+  (threaded* '(org.quartz.SimpleScheduleBuilder/simpleSchedule) nil ctx))
+
+(defn calendar-interval-schedule [ctx]
+  (threaded* '(org.quartz.CalendarIntervalScheduleBuilder/calendarIntervalSchedule) nil ctx))
+
+(defn daily-interval-schedule [ctx]
+  (threaded* '(org.quartz.DailyTimeIntervalScheduleBuilder/dailyTimeIntervalSchedule) nil ctx))
+
+;; cron/schedule takes the builder itself as its first form rather than
+;; constructing one, so there is nothing to prepend.
+(defn cron-schedule [ctx]
+  (threaded* nil nil ctx))

--- a/resources/clj-kondo.exports/clojurewerkz/quartzite/config.edn
+++ b/resources/clj-kondo.exports/clojurewerkz/quartzite/config.edn
@@ -1,8 +1,8 @@
-{:lint-as {clojurewerkz.quartzite.jobs/defjob clojure.core/defn
+{:lint-as {clojurewerkz.quartzite.jobs/defjob               clojure.core/defn
            clojurewerkz.quartzite.stateful/def-stateful-job clojure.core/defn}
- :hooks   {:analyze-call {
-
-
-                          clojurewerkz.quartzite.jobs/build clj-kondo.clojurewerkz.quartzite/jobs-build
-                          clojurewerkz.quartzite.triggers/build clj-kondo.clojurewerkz.quartzite/triggers-build
-                          }}}
+ :hooks   {:analyze-call {clojurewerkz.quartzite.jobs/build                          clj-kondo.clojurewerkz.quartzite/jobs-build
+                          clojurewerkz.quartzite.triggers/build                      clj-kondo.clojurewerkz.quartzite/triggers-build
+                          clojurewerkz.quartzite.schedule.simple/schedule            clj-kondo.clojurewerkz.quartzite/simple-schedule
+                          clojurewerkz.quartzite.schedule.calendar-interval/schedule clj-kondo.clojurewerkz.quartzite/calendar-interval-schedule
+                          clojurewerkz.quartzite.schedule.daily-interval/schedule    clj-kondo.clojurewerkz.quartzite/daily-interval-schedule
+                          clojurewerkz.quartzite.schedule.cron/schedule              clj-kondo.clojurewerkz.quartzite/cron-schedule}}}

--- a/src/clojure/clojurewerkz/quartzite/conversion.clj
+++ b/src/clojure/clojurewerkz/quartzite/conversion.clj
@@ -38,6 +38,8 @@
     to-job-data   [input] "Instantiates a JobDataMap instance from a Clojure map")
   (from-job-data [input] "Converts a JobDataMap to a Clojure map"))
 
+;; each type intentionally implements only the direction that makes sense for it
+#_{:clj-kondo/ignore [:missing-protocol-method]}
 (extend-protocol JobDataMapConversion
   IPersistentMap
   (to-job-data [^IPersistentMap input]
@@ -78,7 +80,8 @@
 
 
 (defprotocol DateConversion
-  (to-date [input] "Converts given input to java.util.Date"))
+  (^Date
+    to-date [input] "Converts given input to java.util.Date"))
 
 (extend-protocol DateConversion
   Date
@@ -103,32 +106,11 @@
 
   LocalDateTime
   (to-date [^LocalDateTime input]
-    (Date/from (.toInstant ^ZonedDateTime (.atZone input ZoneId/systemDefault))))
+    (Date/from (.toInstant ^ZonedDateTime (.atZone input (ZoneId/systemDefault)))))
 
   LocalDate
   (to-date [^LocalDate input]
-    (Date/from (.toInstant ^ZonedDateTime (.atStartOfDay input ZoneId/systemDefault)))))
-
-;; Dynamically load Joda time support if possible
-(defn class-exists? [sym]
-  (try
-    (boolean (resolve sym))
-    (catch Throwable _ false)))
-
-(when (every? class-exists? ['org.joda.time.DateTime
-                             'org.joda.time.MutableDateTime
-                             'org.joda.time.base.BaseDateTime])
-  (eval
-   `(extend-protocol DateConversion
-      org.joda.time.DateTime
-      (to-date [^org.joda.time.DateTime input#]
-        (.toDate input#))
-      org.joda.time.MutableDateTime
-      (to-date [^org.joda.time.MutableDateTime input#]
-        (.toDate input#))
-      org.joda.time.base.BaseDateTime
-      (to-date [^org.joda.time.base.BaseDateTime input#]
-        (.toDate input#)))))
+    (Date/from (.toInstant ^ZonedDateTime (.atStartOfDay input (ZoneId/systemDefault))))))
 
 (defprotocol KeyCoercion
   (^TriggerKey
@@ -136,6 +118,8 @@
   (^JobKey
     to-job-key [input] "Converts a key to a JobKey instance"))
 
+;; TriggerKey and JobKey each coerce to themselves only
+#_{:clj-kondo/ignore [:missing-protocol-method]}
 (extend-protocol KeyCoercion
   TriggerKey
   (to-trigger-key [input]

--- a/src/clojure/clojurewerkz/quartzite/triggers.clj
+++ b/src/clojure/clojurewerkz/quartzite/triggers.clj
@@ -65,7 +65,7 @@
   (.startNow tb))
 
 
-;; Seamless JodaTime integration is one
+;; Seamless java.time integration is one
 ;; of the goals of Quartzite.
 (defn start-at
   ^TriggerBuilder [^TriggerBuilder tb date]

--- a/test/clojurewerkz/quartzite/test/conversion_test.clj
+++ b/test/clojurewerkz/quartzite/test/conversion_test.clj
@@ -1,6 +1,8 @@
 (ns clojurewerkz.quartzite.test.conversion-test
-  (:require [clojure.test :refer [are deftest]]
-            [clojurewerkz.quartzite.conversion :refer [from-job-data to-job-data]]))
+  (:require [clojure.test :refer [are deftest is testing]]
+            [clojurewerkz.quartzite.conversion :refer [from-job-data to-date to-job-data]])
+  (:import (java.time Instant LocalDate LocalDateTime OffsetDateTime ZoneId ZonedDateTime)
+           (java.util Calendar Date)))
 
 (defrecord Abc [a b c])
 
@@ -36,4 +38,31 @@
         ; Check that nested record not converted to map.
         {"record" (->Abc :a :b :c)}
         nil))
+
+
+(deftest test-date-conversion
+  (let [instant (Instant/parse "2035-02-15T12:30:00Z")
+        date    (Date/from instant)]
+    (testing "java.util types"
+      (is (= date (to-date date)))
+      (is (= date (to-date (doto (Calendar/getInstance)
+                             (.setTimeInMillis (.toEpochMilli instant)))))))
+
+    (testing "java.time types carrying an instant"
+      (is (= date (to-date instant)))
+      (is (= date (to-date (OffsetDateTime/ofInstant instant (ZoneId/of "UTC")))))
+      (is (= date (to-date (ZonedDateTime/ofInstant instant (ZoneId/of "UTC")))))))
+
+  (testing "LocalDateTime is interpreted in the system default zone"
+    (let [ldt (LocalDateTime/of 2035 2 15 12 30 0)
+          d   (to-date ldt)]
+      (is (instance? Date d))
+      (is (= ldt (LocalDateTime/ofInstant (.toInstant ^Date d) (ZoneId/systemDefault))))))
+
+  (testing "LocalDate becomes start of day in the system default zone"
+    (let [ld (LocalDate/of 2035 2 15)
+          d  (to-date ld)]
+      (is (instance? Date d))
+      (is (= (.atStartOfDay ld)
+             (LocalDateTime/ofInstant (.toInstant ^Date d) (ZoneId/systemDefault)))))))
 

--- a/test/clojurewerkz/quartzite/test/jobs_test.clj
+++ b/test/clojurewerkz/quartzite/test/jobs_test.clj
@@ -1,5 +1,4 @@
 (ns clojurewerkz.quartzite.test.jobs-test
-  (:refer-clojure :exclude [key])
   (:require [clojure.test :refer [deftest is]]
             [clojurewerkz.quartzite.jobs :as jobs]
             [clojurewerkz.quartzite.conversion :refer [from-job-data to-job-data]])

--- a/test/clojurewerkz/quartzite/test/schedule/daily_interval_test.clj
+++ b/test/clojurewerkz/quartzite/test/schedule/daily_interval_test.clj
@@ -69,7 +69,7 @@
                 (sdi/on-saturday-and-sunday)
                 (sdi/finalize))]
     (is (= i (.getRepeatInterval sched)))
-    (is (= (SimpleTrigger/REPEAT_INDEFINITELY) (.getRepeatCount sched)))))
+    (is (= SimpleTrigger/REPEAT_INDEFINITELY (.getRepeatCount sched)))))
 
 
 (deftest test-daily-interval-schedule-dsl-example6

--- a/test/clojurewerkz/quartzite/test/schedule/simple_test.clj
+++ b/test/clojurewerkz/quartzite/test/schedule/simple_test.clj
@@ -37,7 +37,7 @@
                                    (simple/with-repeat-count        n)
                                    (simple/next-with-remaining-count)
                                    (simple/finalize))]
-    (is (= (* i (DateBuilder/MILLISECONDS_IN_MINUTE)) (.getRepeatInterval sched)))
+    (is (= (* i DateBuilder/MILLISECONDS_IN_MINUTE) (.getRepeatInterval sched)))
     (is (= n (.getRepeatCount    sched)))))
 
 
@@ -49,7 +49,7 @@
                                    (simple/with-repeat-count      n)
                                    (simple/now-with-remaining-count)
                                    (simple/finalize))]
-    (is (= (* i (DateBuilder/MILLISECONDS_IN_HOUR)) (.getRepeatInterval sched)))
+    (is (= (* i DateBuilder/MILLISECONDS_IN_HOUR) (.getRepeatInterval sched)))
     (is (= n (.getRepeatCount    sched)))))
 
 
@@ -60,8 +60,8 @@
                                    (simple/repeat-forever)
                                    (simple/now-with-existing-count)
                                    (simple/finalize))]
-    (is (= (* i (DateBuilder/MILLISECONDS_IN_HOUR)) (.getRepeatInterval sched)))
-    (is (= (SimpleTrigger/REPEAT_INDEFINITELY) (.getRepeatCount sched)))))
+    (is (= (* i DateBuilder/MILLISECONDS_IN_HOUR) (.getRepeatInterval sched)))
+    (is (= SimpleTrigger/REPEAT_INDEFINITELY (.getRepeatCount sched)))))
 
 
 (deftest test-simple-schedule-dsl-example6
@@ -71,4 +71,4 @@
                                    (simple/next-with-existing-count)
                                    (simple/repeat-forever)
                                    (simple/finalize))]
-    (is (= (* 24 i (DateBuilder/MILLISECONDS_IN_HOUR)) (.getRepeatInterval sched)))))
+    (is (= (* 24 i DateBuilder/MILLISECONDS_IN_HOUR) (.getRepeatInterval sched)))))

--- a/test/clojurewerkz/quartzite/test/triggers_test.clj
+++ b/test/clojurewerkz/quartzite/test/triggers_test.clj
@@ -1,10 +1,9 @@
 (ns clojurewerkz.quartzite.test.triggers-test
-  (:refer-clojure :exclude [key])
   (:require [clojurewerkz.quartzite.jobs :as jobs]
             [clojure.test :refer [deftest is]]
-            [clojurewerkz.quartzite.conversion :refer [from-job-data to-job-data]]
+            [clojurewerkz.quartzite.conversion :refer [from-job-data to-date to-job-data]]
             [clojurewerkz.quartzite.triggers :as triggers])
-  (:import (java.time Instant)
+  (:import (java.time Instant LocalDateTime)
            (java.time.temporal ChronoUnit)
            (java.util Date)))
 
@@ -57,6 +56,20 @@
                                 (triggers/end-at   end))]
     (is (= start (.getStartTime trigger)))
     (is (= end   (.getEndTime trigger)))))
+
+
+(deftest test-trigger-builder-dsl-accepts-java-time-types
+  (let [start   (Instant/parse "2035-02-15T12:30:00Z")
+        end     (.plus start 3 ChronoUnit/HOURS)
+        trigger (triggers/build (triggers/with-identity "basic.trigger5a")
+                                (triggers/start-at start)
+                                (triggers/end-at   end))]
+    (is (= (Date/from start) (.getStartTime trigger)))
+    (is (= (Date/from end)   (.getEndTime trigger))))
+  (let [ldt     (LocalDateTime/of 2035 2 15 12 30 0)
+        trigger (triggers/build (triggers/with-identity "basic.trigger5b")
+                                (triggers/start-at ldt))]
+    (is (= (to-date ldt) (.getStartTime trigger)))))
 
 
 (deftest test-trigger-builder-dsl-example6


### PR DESCRIPTION
…do exports

Quartz moves to 2.5.2; the 2.5.0 upgrade had been deferred pending quartz-scheduler/quartz#1298, since resolved, so the stale comment goes with the bump.

Fix `to-date` for LocalDateTime and LocalDate, which threw IllegalArgumentException and ClassCastException respectively: `ZoneId/systemDefault` was missing parentheses, which Clojure 1.12 compiles to a method value rather than a call. Both are now tested.

Tag `to-date` as returning java.util.Date so triggers/start-at and end-at resolve against startAt(Date) instead of reflecting over the startAt(Instant) overload Quartz 2.5 added. DateConversion implementations are consequently expected to return a java.util.Date.

BREAKING: remove the dynamic extension of DateConversion to org.joda.time types. The direct clj-time dependency was already gone; this drops the extend-protocol block that still fired when Joda Time happened to be on the classpath. See ChangeLog.md for the migration.

Register clj-kondo hooks for the schedule threading macros in schedule.simple, .calendar-interval, .daily-interval and .cron so linting DSL code no longer reports spurious arity errors, and clear the remaining lint issues in the library and tests.